### PR TITLE
fix: cancel all derivative orders not working

### DIFF
--- a/app/services/portfolio.ts
+++ b/app/services/portfolio.ts
@@ -6,17 +6,13 @@ import {
   PositionStreamCallback
 } from '@injectivelabs/derivatives-consumer'
 import {
-  SpotMarketComposer,
   SpotMarketStreamType,
   SpotTransformer,
   OrderStreamCallback as SpotMarketOrderStreamCallback
 } from '@injectivelabs/spot-consumer'
-import { Web3Exception } from '@injectivelabs/exceptions'
 import { metricsProvider } from '../providers/MetricsProvider'
 import { derivativeConsumer } from '../singletons/DerivativeMarketConsumer'
 import { spotConsumer } from '../singletons/SpotMarketConsumer'
-import { TxProvider } from '../providers/TxProvider'
-import { CHAIN_ID } from '../utils/constants'
 import { streamProvider } from '../providers/StreamProvider'
 import { spotMarketStream } from '../singletons/SpotMarketStream'
 import { derivativeMarketStream } from '../singletons/DerivativeMarketStream'
@@ -87,74 +83,6 @@ export const fetchDerivativeOrderbooks = async (marketIds: string[]) => {
   return marketIds.reduce((derivativeOrderbooks, marketId, index) => {
     return { ...derivativeOrderbooks, [marketId]: orderbooks[index] }
   }, {} as Record<string, UiDerivativeOrderbook>)
-}
-
-export const cancelOrder = async ({
-  orderHash,
-  address,
-  marketId,
-  injectiveAddress,
-  subaccountId
-}: {
-  orderHash: string
-  subaccountId: string
-  marketId: string
-  address: string
-  injectiveAddress: string
-}) => {
-  const message = SpotMarketComposer.cancelSpotOrder({
-    subaccountId,
-    marketId,
-    injectiveAddress,
-    order: {
-      orderHash
-    }
-  })
-
-  try {
-    const txProvider = new TxProvider({
-      address,
-      message,
-      bucket: SpotMetrics.CancelLimitOrder,
-      chainId: CHAIN_ID
-    })
-
-    await txProvider.broadcast()
-  } catch (error: any) {
-    throw new Web3Exception(error.message)
-  }
-}
-
-export const batchCancelOrders = async ({
-  orders,
-  address,
-  injectiveAddress
-}: {
-  orders: {
-    subaccountId: string
-    marketId: string
-    orderHash: string
-  }[]
-  address: string
-  injectiveAddress: string
-}) => {
-  const message = SpotMarketComposer.batchCancelSpotOrder({
-    injectiveAddress,
-    orders
-  })
-
-  try {
-    const txProvider = new TxProvider({
-      address,
-      message,
-      bucket: SpotMetrics.BatchCancelLimitOrders,
-      chainId: CHAIN_ID
-    })
-
-    await txProvider.broadcast()
-  } catch (error: any) {
-    throw new Web3Exception(error.message)
-  }
 }
 
 export const streamSubaccountSpotOrders = ({

--- a/components/partials/portfolio/open-orders.vue
+++ b/components/partials/portfolio/open-orders.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
       const { spotOrders } = this
 
       this.$accessor.portfolio
-        .batchCancelOrder(spotOrders)
+        .batchCancelSpotOrders(spotOrders)
         .then(() => {
           this.$toast.success(this.$t('orders_cancelled'))
         })
@@ -147,7 +147,7 @@ export default Vue.extend({
       const { derivativeOrders } = this
 
       this.$accessor.portfolio
-        .batchCancelOrder(derivativeOrders)
+        .batchCancelDerivativeOrders(derivativeOrders)
         .then(() => {
           this.$toast.success(this.$t('orders_cancelled'))
         })

--- a/components/partials/portfolio/open-positions.vue
+++ b/components/partials/portfolio/open-positions.vue
@@ -76,19 +76,23 @@ export default Vue.extend({
     closeAllPosition() {
       const { positions } = this
 
-      const positionsToCancel = positions.map((position) => {
-        const market = this.getMarket(position.marketId) as UiDerivativeMarket
+      const positionsToCancel = positions
+        .map((position) => {
+          const market = this.getMarket(position.marketId) as UiDerivativeMarket
 
-        return {
-          market,
-          price: getPositionFeeAdjustedBankruptcyPrice({ position, market }),
-          orderType:
-            position.direction === TradeDirection.Long
-              ? DerivativeOrderSide.Sell
-              : DerivativeOrderSide.Buy,
-          quantity: new BigNumberInBase(position.quantity)
-        }
-      })
+          return {
+            market,
+            price: market
+              ? getPositionFeeAdjustedBankruptcyPrice({ position, market })
+              : new BigNumberInBase(0),
+            orderType:
+              position.direction === TradeDirection.Long
+                ? DerivativeOrderSide.Sell
+                : DerivativeOrderSide.Buy,
+            quantity: new BigNumberInBase(position.quantity)
+          }
+        })
+        .filter(({ market }) => market !== undefined)
 
       this.$accessor.derivatives
         .closeAllPosition({

--- a/plugins/store.ts
+++ b/plugins/store.ts
@@ -29,7 +29,8 @@ const actionsThatSetAppStateToBusy = [
   'spot/submitMarketOrder',
   'portfolio/closePosition',
   'portfolio/cancelOrder',
-  'portfolio/batchCancelOrder'
+  'portfolio/batchCancelSpotOrders',
+  'portfolio/batchCancelDerivativeOrders'
 ]
 
 const store: Plugin = ({ store, app }, inject) => {

--- a/store/portfolio.ts
+++ b/store/portfolio.ts
@@ -13,13 +13,15 @@ import {
   streamSubaccountSpotOrders,
   streamSubaccountDerivativeOrders,
   cancelPortfolioStreams,
-  batchCancelOrders,
   streamSubaccountPositions,
   fetchSubaccountPositions,
   streamOrderbooks,
   fetchDerivativeOrderbooks,
   cancelPortfolioOrderbookStreams
 } from '~/app/services/portfolio'
+
+import { batchCancelOrders as batchCancelDerivativeOrders } from '~/app/services/derivatives'
+import { batchCancelOrders as batchCancelSpotOrders } from '~/app/services/spot'
 
 const initialStateFactory = () => ({
   subaccountOrders: [] as Array<UiSpotLimitOrder | UiDerivativeLimitOrder>,
@@ -341,9 +343,9 @@ export const actions = actionTree(
       })
     },
 
-    async batchCancelOrder(
+    async batchCancelSpotOrders(
       _,
-      orders: Array<UiSpotLimitOrder | UiDerivativeLimitOrder>
+      orders: UiSpotLimitOrder[]
     ) {
       const { subaccount } = this.app.$accessor.account
       const {
@@ -359,7 +361,36 @@ export const actions = actionTree(
       await this.app.$accessor.app.queue()
       await this.app.$accessor.wallet.validate()
 
-      await batchCancelOrders({
+      await batchCancelSpotOrders({
+        injectiveAddress,
+        address,
+        orders: orders.map((o) => ({
+          orderHash: o.orderHash,
+          subaccountId: o.subaccountId,
+          marketId: o.marketId
+        }))
+      })
+    },
+
+    async batchCancelDerivativeOrders(
+      _,
+      orders: UiDerivativeLimitOrder[]
+    ) {
+      const { subaccount } = this.app.$accessor.account
+      const {
+        address,
+        injectiveAddress,
+        isUserWalletConnected
+      } = this.app.$accessor.wallet
+
+      if (!isUserWalletConnected || !subaccount) {
+        return
+      }
+
+      await this.app.$accessor.app.queue()
+      await this.app.$accessor.wallet.validate()
+
+      await batchCancelDerivativeOrders({
         injectiveAddress,
         address,
         orders: orders.map((o) => ({


### PR DESCRIPTION
## This PR:
- resolves #340 
- also added a fix - resolving `close all position` trying to close unavailable market positions i.e. `GRT/USDT` (this should be a Testnet specific issue)