### PR TITLE
fix: order book aggregation filtering regression issues

### DIFF
--- a/app/services/derivatives.ts
+++ b/app/services/derivatives.ts
@@ -35,6 +35,7 @@ import {
   UiDerivativeMarket,
   UiDerivativeMarketSummary,
   UiPosition,
+  UiSpotMarket,
   BaseUiDerivativeMarketWithTokenMetaData,
   TradeDirection,
   Token
@@ -710,6 +711,20 @@ export const calculateMargin = ({
   leverage: string
 }): BigNumberInBase => {
   return new BigNumberInBase(quantity).times(price).dividedBy(leverage)
+}
+
+export const getAggregationPrice = ({
+  price,
+  aggregation
+}: {
+  price: BigNumberInBase
+  aggregation: number
+}): string => {
+  const aggregateBy = new BigNumberInBase(10 ** aggregation)
+
+  return new BigNumberInBase(price.multipliedBy(aggregateBy))
+    .dividedBy(aggregateBy)
+    .toFormat()
 }
 
 export const getPositionFeeAdjustedBankruptcyPrice = ({

--- a/app/services/derivatives.ts
+++ b/app/services/derivatives.ts
@@ -35,7 +35,6 @@ import {
   UiDerivativeMarket,
   UiDerivativeMarketSummary,
   UiPosition,
-  UiSpotMarket,
   BaseUiDerivativeMarketWithTokenMetaData,
   TradeDirection,
   Token

--- a/app/services/spot.ts
+++ b/app/services/spot.ts
@@ -491,6 +491,20 @@ export const calculateAverageExecutionPriceFromOrderbook = ({
   return sum.div(amount.minus(remainAmountToFill))
 }
 
+export const getAggregationPrice = ({
+  price,
+  aggregation
+}: {
+  price: BigNumberInBase
+  aggregation: number
+}): string => {
+  const aggregateBy = new BigNumberInBase(10 ** aggregation)
+
+  return new BigNumberInBase(price.multipliedBy(aggregateBy))
+    .dividedBy(aggregateBy)
+    .toFormat()
+}
+
 export const getApproxAmountForMarketOrder = ({
   records,
   balance,

--- a/components/partials/derivatives/orderbook/order-book.vue
+++ b/components/partials/derivatives/orderbook/order-book.vue
@@ -74,6 +74,7 @@ import {
   BigNumberInWei
 } from '@injectivelabs/utils'
 import Record from './record.vue'
+import { getAggregationPrice } from '~/app/services/derivatives'
 import {
   UI_DEFAULT_PRICE_DISPLAY_DECIMALS,
   ZERO_IN_BASE
@@ -226,22 +227,22 @@ export default Vue.extend({
         return []
       }
 
-      const orders = {} as Record<number, any>
+      const orders = {} as Record<string, any>
       buys.forEach((record: UiPriceLevel) => {
         const price = new BigNumberInBase(
           new BigNumberInWei(record.price)
             .toBase(market.quoteToken.decimals)
-            .toFormat(aggregation)
+            .decimalPlaces(aggregation)
         )
 
-        const dividerValue = 10 ** aggregation
-
-        const priceKey =
-          Math.floor(price.toNumber() * dividerValue) / dividerValue
-        orders[priceKey] = (orders[priceKey] || []).concat({
-          ...record,
-          displayPrice: price
-        })
+        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        orders[aggregatedPriceKey] = [
+          ...(orders[aggregatedPriceKey] || []),
+          {
+            ...record,
+            displayPrice: price
+          }
+        ]
       })
 
       return Object.entries(orders).map(([, orderGroup]) => {
@@ -288,7 +289,7 @@ export default Vue.extend({
           const v1Price = new BigNumberInWei(v1.price)
           const v2Price = new BigNumberInWei(v2.price)
 
-          return v1Price.minus(v2Price).toNumber()
+          return v2Price.minus(v1Price).toNumber()
         })
         .map((record: UiPriceLevel, index: number) => {
           const notional = record.notional || new BigNumberInBase(0)
@@ -313,21 +314,22 @@ export default Vue.extend({
         return []
       }
 
-      const orders = {} as Record<number, any>
+      const orders = {} as Record<string, any>
       sells.forEach((record: UiPriceLevel, index: number) => {
         const price = new BigNumberInBase(
           new BigNumberInWei(record.price)
             .toBase(market.quoteToken.decimals)
-            .toFormat(aggregation, BigNumber.ROUND_CEIL)
+            .decimalPlaces(aggregation, BigNumber.ROUND_CEIL)
         )
 
-        const dividerValue = 10 ** aggregation
-        const priceKey =
-          Math.floor(price.toNumber() * dividerValue) / dividerValue
-        orders[priceKey] = (orders[priceKey] || []).concat({
-          ...record,
-          displayPrice: price
-        })
+        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        orders[aggregatedPriceKey] = [
+          ...(orders[aggregatedPriceKey] || []),
+          {
+            ...record,
+            displayPrice: price
+          }
+        ]
       })
 
       return Object.entries(orders)


### PR DESCRIPTION
## This PR:
- resolves multiple order-book aggregation filtering regression issues:
    -  [buy orders wrong sorting](https://discord.com/channels/739552603322450092/750697249129889874/907978802074878023)
    - [btc pairing markets showing NaN on orderbook](https://discord.com/channels/739552603322450092/750697249129889874/907981060288172082)

## Screenshot:
![image](https://user-images.githubusercontent.com/10151054/141138977-f92b31c0-5cd6-4ed5-85d3-a6e9361ee63c.png)
