### PR TITLE
Fixed leverage box appearance

### DIFF
--- a/assets/css/components/_inputs.scss
+++ b/assets/css/components/_inputs.scss
@@ -71,7 +71,7 @@
 }
 
 .leverage-input {
-  @apply font-mono ml-2 w-14 py-1 text-sm text-right rounded-lg appearance-none bg-gray-900 text-gray-300;
+  @apply font-mono ml-2 w-16 py-1 text-sm text-right rounded-lg appearance-none bg-gray-900 text-gray-300;
 
   /* Chrome, Safari, Edge, Opera */
   &::-webkit-outer-spin-button,

--- a/components/partials/derivatives/trading/order-leverage.vue
+++ b/components/partials/derivatives/trading/order-leverage.vue
@@ -25,7 +25,7 @@
           class="leverage-input pr-4"
           @input="(e) => onLeverageChange(e.target.value)"
         />
-        <span class="absolute top-0 right-0 text-xs text-gray-400 mt-1 mr-1">
+        <span class="absolute top-0 right-0 text-xs text-gray-400 mt-1.5 mr-1.5">
           x
         </span>
       </div>


### PR DESCRIPTION
## Description
> Fixed width and added some padding to the leverage text component.

## CL
- Increased the width of the leverage box
- Slightly increased  right and top padding for `x` to level it with text

## Related Issues
- Resolves #366 

`Earlier`

![Leverage Earlier](https://user-images.githubusercontent.com/23742447/141660666-80723536-ad71-4c12-b485-7bc407fde047.png)

`Modified`

![Leverage Modified](https://user-images.githubusercontent.com/23742447/141660687-a07c38ea-9759-4593-8ae4-fa12845ae31b.png)

