### PR TITLE
fix: orderbook price aggregations not base on minPriceTickSize

### DIFF
--- a/components/partials/common/orderbook/aggregation-selector.vue
+++ b/components/partials/common/orderbook/aggregation-selector.vue
@@ -8,7 +8,7 @@
 
     <div class="text-center cursor-pointer">
       <SelectorItem
-        v-for="item in list"
+        v-for="item in filteredList"
         :key="`list-${item.value}`"
         :item="item"
         @click="handleClick"
@@ -34,12 +34,29 @@ export default Vue.extend({
     value: {
       type: Number,
       required: true
+    },
+
+    minTick: {
+      type: Number,
+      required: true
     }
   },
 
   data() {
     return {
       list: [
+        {
+          value: -2,
+          text: '100'
+        },
+        {
+          value: -1,
+          text: '10'
+        },
+        {
+          value: 0,
+          text: '1'
+        },
         {
           value: 1,
           text: '0.1'
@@ -61,6 +78,14 @@ export default Vue.extend({
       const { list, value } = this
 
       return list.find((item) => value === item.value)?.text || ''
+    },
+
+    filteredList(): Record<string, any>[] {
+      const { minTick, list } = this
+
+      const index = list.findIndex(({ value }) => value === minTick)
+
+      return [...list].slice(Math.max(index - 3, 0), index + 1)
     }
   },
 

--- a/components/partials/derivatives/orderbook.vue
+++ b/components/partials/derivatives/orderbook.vue
@@ -27,6 +27,7 @@
       <v-aggregation-selector
         v-if="component === components.orderbook"
         class="pr-2"
+        :min-tick="minTick"
         :value="aggregation"
         @click="handleAggregationChange"
       />
@@ -64,15 +65,18 @@ export default Vue.extend({
   data() {
     return {
       aggregation: UI_DEFAULT_AGGREGATION_DECIMALS, // default aggregation decimal
+      minTick: UI_DEFAULT_AGGREGATION_DECIMALS,
       components,
       component: components.orderbook
     }
   },
 
   mounted() {
-    this.aggregation =
-      this.$accessor.spot.market?.priceDecimals ||
-      UI_DEFAULT_AGGREGATION_DECIMALS
+    const market = this.$accessor.derivatives.market
+    if (market && market.priceDecimals) {
+      this.aggregation = 1
+      this.minTick = 1
+    }
   },
 
   methods: {

--- a/components/partials/derivatives/orderbook/order-book.vue
+++ b/components/partials/derivatives/orderbook/order-book.vue
@@ -68,11 +68,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import {
-  BigNumber,
-  BigNumberInBase,
-  BigNumberInWei
-} from '@injectivelabs/utils'
+import { BigNumberInBase, BigNumberInWei } from '@injectivelabs/utils'
 import Record from './record.vue'
 import { getAggregationPrice } from '~/app/services/derivatives'
 import {
@@ -230,17 +226,21 @@ export default Vue.extend({
       const orders = {} as Record<string, any>
       buys.forEach((record: UiPriceLevel) => {
         const price = new BigNumberInBase(
-          new BigNumberInWei(record.price)
-            .toBase(market.quoteToken.decimals)
-            .decimalPlaces(aggregation, BigNumber.ROUND_FLOOR)
+          new BigNumberInWei(record.price).toBase(market.quoteToken.decimals)
         )
 
-        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        const aggregatedPrice = getAggregationPrice({
+          price,
+          aggregation,
+          isBuy: true
+        })
+        const aggregatedPriceKey = aggregatedPrice.toFormat()
+
         orders[aggregatedPriceKey] = [
           ...(orders[aggregatedPriceKey] || []),
           {
             ...record,
-            displayPrice: price
+            displayPrice: aggregatedPrice
           }
         ]
       })
@@ -317,17 +317,21 @@ export default Vue.extend({
       const orders = {} as Record<string, any>
       sells.forEach((record: UiPriceLevel, index: number) => {
         const price = new BigNumberInBase(
-          new BigNumberInWei(record.price)
-            .toBase(market.quoteToken.decimals)
-            .decimalPlaces(aggregation, BigNumber.ROUND_CEIL)
+          new BigNumberInWei(record.price).toBase(market.quoteToken.decimals)
         )
 
-        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        const aggregatedPrice = getAggregationPrice({
+          price,
+          aggregation,
+          isBuy: false
+        })
+        const aggregatedPriceKey = aggregatedPrice.toFormat()
+
         orders[aggregatedPriceKey] = [
           ...(orders[aggregatedPriceKey] || []),
           {
             ...record,
-            displayPrice: price
+            displayPrice: aggregatedPrice
           }
         ]
       })

--- a/components/partials/derivatives/orderbook/record.vue
+++ b/components/partials/derivatives/orderbook/record.vue
@@ -25,7 +25,7 @@
         }"
       >
         <v-number
-          :decimals="aggregation"
+          :decimals="aggregation < 0 ? 0 : aggregation"
           :number="record.displayPrice"
           dont-group-values
         />

--- a/components/partials/spot/orderbook.vue
+++ b/components/partials/spot/orderbook.vue
@@ -27,6 +27,7 @@
       <v-aggregation-selector
         v-if="component === components.orderbook"
         class="pr-2"
+        :min-tick="minTick"
         :value="aggregation"
         @click="handleAggregationChange"
       />
@@ -64,15 +65,18 @@ export default Vue.extend({
   data() {
     return {
       aggregation: UI_DEFAULT_AGGREGATION_DECIMALS, // default aggregation decimal
+      minTick: UI_DEFAULT_AGGREGATION_DECIMALS,
       components,
       component: components.orderbook
     }
   },
 
   mounted() {
-    this.aggregation =
-      this.$accessor.spot.market?.priceDecimals ||
-      UI_DEFAULT_AGGREGATION_DECIMALS
+    const market = this.$accessor.spot.market
+    if (market && market.priceDecimals) {
+      this.aggregation = market.priceDecimals
+      this.minTick = market.priceDecimals
+    }
   },
 
   methods: {

--- a/components/partials/spot/orderbook/order-book.vue
+++ b/components/partials/spot/orderbook/order-book.vue
@@ -68,11 +68,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import {
-  BigNumber,
-  BigNumberInBase,
-  BigNumberInWei
-} from '@injectivelabs/utils'
+import { BigNumberInBase, BigNumberInWei } from '@injectivelabs/utils'
 import Record from './record.vue'
 import { getAggregationPrice } from '~/app/services/spot'
 import {
@@ -223,19 +219,23 @@ export default Vue.extend({
       const orders = {} as Record<string, any>
       buys.forEach((record: UiPriceLevel) => {
         const price = new BigNumberInBase(
-          new BigNumberInBase(
-            new BigNumberInBase(record.price).toWei(
-              market.baseToken.decimals - market.quoteToken.decimals
-            )
-          ).decimalPlaces(aggregation, BigNumber.ROUND_FLOOR)
+          new BigNumberInBase(record.price).toWei(
+            market.baseToken.decimals - market.quoteToken.decimals
+          )
         )
 
-        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        const aggregatedPrice = getAggregationPrice({
+          price,
+          aggregation,
+          isBuy: true
+        })
+        const aggregatedPriceKey = aggregatedPrice.toFormat()
+
         orders[aggregatedPriceKey] = [
           ...(orders[aggregatedPriceKey] || []),
           {
             ...record,
-            displayPrice: price
+            displayPrice: aggregatedPrice
           }
         ]
       })
@@ -312,19 +312,23 @@ export default Vue.extend({
       const orders = {} as Record<string, any>
       sells.forEach((record: UiPriceLevel, index: number) => {
         const price = new BigNumberInBase(
-          new BigNumberInBase(
-            new BigNumberInBase(record.price).toWei(
-              market.baseToken.decimals - market.quoteToken.decimals
-            )
-          ).decimalPlaces(aggregation, BigNumber.ROUND_CEIL)
+          new BigNumberInBase(record.price).toWei(
+            market.baseToken.decimals - market.quoteToken.decimals
+          )
         )
 
-        const aggregatedPriceKey = getAggregationPrice({ price, aggregation })
+        const aggregatedPrice = getAggregationPrice({
+          price,
+          aggregation,
+          isBuy: false
+        })
+        const aggregatedPriceKey = aggregatedPrice.toFormat()
+
         orders[aggregatedPriceKey] = [
           ...(orders[aggregatedPriceKey] || []),
           {
             ...record,
-            displayPrice: price
+            displayPrice: aggregatedPrice
           }
         ]
       })

--- a/components/partials/spot/orderbook/record.vue
+++ b/components/partials/spot/orderbook/record.vue
@@ -25,7 +25,7 @@
         }"
       >
         <v-number
-          :decimals="aggregation"
+          :decimals="aggregation < 0 ? 0 : aggregation"
           :number="record.displayPrice"
           dont-group-values
         />


### PR DESCRIPTION
## This PR:
- resolves #384 
- the new changes should be dynamic enough to support scaling base on minPriceTickSize in the following format:
   - **0.1** -> `0.1, 1, 10, 1000`
   - **0.01** -> `0.01, 0.1, 1, 10`
   - **0.001** -> `0.001, 0.01, 0.1, 1`
- do note testing this implementation will testnet and devnet will not be accurate as the minPriceTickSize for BTC is set to 0.001. I've manually override the minPriceTickSize and the implementation works as designed (screenshots attached below).


## Screenshots:
- ### `0.001` minPriceTickSize:
![image](https://user-images.githubusercontent.com/10151054/142155688-ba7d5540-49b5-4935-b1b1-bd7bd09ba4a3.png)
- ### `0.1` minPriceTickSize:
![image](https://user-images.githubusercontent.com/10151054/142155821-1ccbb579-b01b-438c-9517-d471b654320b.png)

