### PR TITLE
chore: hardcode axs/usdt reward maker multiplier to zero

### DIFF
--- a/components/partials/trade-and-earn/markets-info/boosted.vue
+++ b/components/partials/trade-and-earn/markets-info/boosted.vue
@@ -146,12 +146,17 @@ export default Vue.extend({
 
       const spot = spotMarketsTickerBasedOnIds.reduce(
         (records, ticker, index) => {
+          const hardCodeMakerToZero = ticker === 'AXS/USDT'
+
           return [
             ...records,
             {
               ticker,
               makerPointsMultiplier: cosmosSdkDecToBigNumber(
-                spotMarketsBoosts[index].makerPointsMultiplier
+                // hardcode maker to 0
+                hardCodeMakerToZero
+                  ? 0
+                  : spotMarketsBoosts[index].makerPointsMultiplier
               ).toFixed(),
               takerPointsMultiplier: cosmosSdkDecToBigNumber(
                 spotMarketsBoosts[index].takerPointsMultiplier


### PR DESCRIPTION
## This PR:
- hardcodes the AXS/USDT marker multiplier on the rewards page to zero.
- note that this PR will only hardcode the FE reflection of the maker rate on the rewards page, it does not alter any other logic related to the trading rewards implementation. 