### PR TITLE
fix: order book aggregated price level showing 0 price issue

### DIFF
--- a/app/services/derivatives.ts
+++ b/app/services/derivatives.ts
@@ -727,14 +727,17 @@ export const getAggregationPrice = ({
   isBuy: boolean
 }): BigNumberInBase => {
   const aggregateBy = new BigNumberInBase(10 ** Math.abs(aggregation))
-  if (aggregation < 0) {
+  if (aggregation <= 0) {
     // handles 10, 100 and 1000
-    return new BigNumberInBase(
+    const aggregatedValue = new BigNumberInBase(
       price
         .dividedBy(aggregateBy)
         .integerValue(isBuy ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL)
         .multipliedBy(aggregateBy)
     )
+
+    // prevents orderbook displaying 0 value
+    return aggregateBy.gt(aggregatedValue) ? aggregateBy : aggregatedValue
   }
 
   return new BigNumberInBase(

--- a/app/services/derivatives.ts
+++ b/app/services/derivatives.ts
@@ -729,15 +729,12 @@ export const getAggregationPrice = ({
   const aggregateBy = new BigNumberInBase(10 ** Math.abs(aggregation))
   if (aggregation <= 0) {
     // handles 10, 100 and 1000
-    const aggregatedValue = new BigNumberInBase(
+    return new BigNumberInBase(
       price
         .dividedBy(aggregateBy)
         .integerValue(isBuy ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL)
         .multipliedBy(aggregateBy)
     )
-
-    // prevents orderbook displaying 0 value
-    return aggregateBy.gt(aggregatedValue) ? aggregateBy : aggregatedValue
   }
 
   return new BigNumberInBase(

--- a/app/services/spot.ts
+++ b/app/services/spot.ts
@@ -508,15 +508,12 @@ export const getAggregationPrice = ({
   const aggregateBy = new BigNumberInBase(10 ** Math.abs(aggregation))
   if (aggregation <= 0) {
     // handles 10, 100 and 1000
-    const aggregatedValue = new BigNumberInBase(
+    return new BigNumberInBase(
       price
         .dividedBy(aggregateBy)
         .integerValue(isBuy ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL)
         .multipliedBy(aggregateBy)
     )
-
-    // prevents orderbook displaying 0 value
-    return aggregateBy.gt(aggregatedValue) ? aggregateBy : aggregatedValue
   }
 
   return new BigNumberInBase(

--- a/app/services/spot.ts
+++ b/app/services/spot.ts
@@ -506,14 +506,17 @@ export const getAggregationPrice = ({
   isBuy: boolean
 }): BigNumberInBase => {
   const aggregateBy = new BigNumberInBase(10 ** Math.abs(aggregation))
-  if (aggregation < 0) {
+  if (aggregation <= 0) {
     // handles 10, 100 and 1000
-    return new BigNumberInBase(
+    const aggregatedValue = new BigNumberInBase(
       price
         .dividedBy(aggregateBy)
         .integerValue(isBuy ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL)
         .multipliedBy(aggregateBy)
     )
+
+    // prevents orderbook displaying 0 value
+    return aggregateBy.gt(aggregatedValue) ? aggregateBy : aggregatedValue
   }
 
   return new BigNumberInBase(

--- a/components/partials/common/orderbook/aggregation-selector.vue
+++ b/components/partials/common/orderbook/aggregation-selector.vue
@@ -85,7 +85,7 @@ export default Vue.extend({
 
       const index = list.findIndex(({ value }) => value === minTick)
 
-      return [...list].slice(Math.max(index - 3, 0), index + 1)
+      return list.slice(Math.max(index - 3, 0), index + 1)
     }
   },
 

--- a/components/partials/derivatives/orderbook/record.vue
+++ b/components/partials/derivatives/orderbook/record.vue
@@ -27,9 +27,17 @@
         }"
       >
         <v-number
-          :prefix="aggregatedValue.gte(record.aggregatedPrice) ? '<' : ''"
+          :prefix="
+            aggregatedValue.gt(record.aggregatedPrice) && recordTypeBuy
+              ? '<'
+              : ''
+          "
           :decimals="aggregation < 0 ? 0 : aggregation"
-          :number="record.aggregatedPrice"
+          :number="
+            aggregatedValue.gt(record.aggregatedPrice)
+              ? aggregatedValue
+              : record.aggregatedPrice
+          "
           dont-group-values
         />
       </span>

--- a/components/partials/derivatives/orderbook/record.vue
+++ b/components/partials/derivatives/orderbook/record.vue
@@ -27,6 +27,7 @@
         }"
       >
         <v-number
+          :prefix="aggregatedValue.gte(record.aggregatedPrice) ? '<' : ''"
           :decimals="aggregation < 0 ? 0 : aggregation"
           :number="record.aggregatedPrice"
           dont-group-values
@@ -210,6 +211,14 @@ export default Vue.extend({
       }
 
       return oldQuantityBN.gte(quantityBN) ? Change.Decrease : Change.Increase
+    },
+
+    aggregatedValue(): BigNumberInBase {
+      const { aggregation } = this
+
+      const value = new BigNumberInBase(10 ** Math.abs(aggregation))
+
+      return aggregation < 0 ? value : new BigNumberInBase(1).dividedBy(value)
     }
   },
 

--- a/components/partials/spot/orderbook/record.vue
+++ b/components/partials/spot/orderbook/record.vue
@@ -27,6 +27,7 @@
         }"
       >
         <v-number
+          :prefix="aggregatedValue.gte(record.aggregatedPrice) ? '<' : ''"
           :decimals="aggregation < 0 ? 0 : aggregation"
           :number="record.aggregatedPrice"
           dont-group-values
@@ -211,6 +212,14 @@ export default Vue.extend({
       }
 
       return oldQuantityBN.gte(quantityBN) ? Change.Decrease : Change.Increase
+    },
+
+    aggregatedValue(): BigNumberInBase {
+      const { aggregation } = this
+
+      const value = new BigNumberInBase(10 ** Math.abs(aggregation))
+
+      return aggregation < 0 ? value : new BigNumberInBase(1).dividedBy(value)
     }
   },
 

--- a/components/partials/spot/orderbook/record.vue
+++ b/components/partials/spot/orderbook/record.vue
@@ -27,9 +27,17 @@
         }"
       >
         <v-number
-          :prefix="aggregatedValue.gte(record.aggregatedPrice) ? '<' : ''"
+          :prefix="
+            aggregatedValue.gt(record.aggregatedPrice) && recordTypeBuy
+              ? '<'
+              : ''
+          "
           :decimals="aggregation < 0 ? 0 : aggregation"
-          :number="record.aggregatedPrice"
+          :number="
+            aggregatedValue.gt(record.aggregatedPrice)
+              ? aggregatedValue
+              : record.aggregatedPrice
+          "
           dont-group-values
         />
       </span>


### PR DESCRIPTION
## This PR:
- resolves #402 

## Screenshots:
- ### Tested the implementation using ZRX on a `10` and `1` aggregate, manually enabled `10` for testing on my local machine.
|Aggregate by 0.1 | Aggregate by 1 | Aggregate by 10 |
|----|----|----|
| ![image](https://user-images.githubusercontent.com/10151054/142581442-1da08de6-da44-4aab-8fe4-5f167e7f76cc.png) | ![image](https://user-images.githubusercontent.com/10151054/142599652-dd5e20cd-4104-4ba4-ade3-1e6328541e99.png) | ![image](https://user-images.githubusercontent.com/10151054/142599770-b607e223-a19d-453b-aa9f-39cfe4dc2a1a.png) |
