### PR TITLE
feat: updates spot market order details format to follow derivative order details format

### DIFF
--- a/components/partials/spot/trading/order-details-market.vue
+++ b/components/partials/spot/trading/order-details-market.vue
@@ -17,11 +17,7 @@
             <span class="mr-1">≈</span>
             {{ extractedTotalToFormat }}
             <span class="text-gray-500 ml-1">
-              {{
-                orderTypeBuy
-                  ? market.quoteToken.symbol
-                  : market.baseToken.symbol
-              }}
+              {{ market.quoteToken.symbol }}
             </span>
           </span>
         </v-text-info>
@@ -32,11 +28,7 @@
           <span v-if="!amount.isNaN()" class="font-mono flex items-center">
             {{ amountToFormat }}
             <span class="text-gray-500 ml-1">
-              {{
-                orderTypeBuy
-                  ? market.quoteToken.symbol
-                  : market.baseToken.symbol
-              }}
+              {{ market.baseToken.symbol }}
             </span>
           </span>
           <span v-else class="text-gray-500 ml-1"> &mdash; </span>
@@ -257,33 +249,23 @@ export default Vue.extend({
     },
 
     extractedTotal(): BigNumberInBase {
-      const { totalWithFees, amount, orderTypeBuy } = this
-
-      if (orderTypeBuy) {
-        return totalWithFees
-      }
+      const { totalWithFees, amount } = this
 
       if (amount.isNaN()) {
         return ZERO_IN_BASE
       }
 
-      return amount
+      return totalWithFees
     },
 
     extractedTotalToFormat(): string {
-      const { extractedTotal, orderTypeBuy, market } = this
+      const { extractedTotal, market } = this
 
       if (!market) {
-        return extractedTotal.toFormat(
-          orderTypeBuy
-            ? UI_DEFAULT_PRICE_DISPLAY_DECIMALS
-            : UI_DEFAULT_AMOUNT_DISPLAY_DECIMALS
-        )
+        return extractedTotal.toFormat(UI_DEFAULT_PRICE_DISPLAY_DECIMALS)
       }
 
-      return extractedTotal.toFormat(
-        orderTypeBuy ? market.priceDecimals : market.quantityDecimals
-      )
+      return extractedTotal.toFormat(market.priceDecimals)
     },
 
     totalToFormat(): string {


### PR DESCRIPTION
## This PR:
- resolves #421
- updates spot market order details format to follow derivative order details format

## Note: this PR is not ready to be merged yet, @cmhchoi wants to confirm this implementation with the trading team, please merge this only after he approves the PR.

## Screenshots:
- ### Before
| buy order details | sell order details |
|----|----|
| ![image](https://user-images.githubusercontent.com/10151054/142828594-615b2e93-2239-4714-89a4-3da63bb25eab.png) | ![image](https://user-images.githubusercontent.com/10151054/142828635-b8939b0f-daa2-4110-ab06-23af48639e69.png) |

- ### After
| buy order details | sell order details |
|----|----|
| ![image](https://user-images.githubusercontent.com/10151054/142828391-936840f0-2e35-49bc-aa3b-34831fe211ad.png) | ![image](https://user-images.githubusercontent.com/10151054/142828433-f584ccd5-b129-481c-b633-c9749307ac78.png) |
