### PR TITLE
chore: set custom aggregation for bnb btc and eth markets

### DIFF
--- a/app/data/aggregation.ts
+++ b/app/data/aggregation.ts
@@ -1,0 +1,68 @@
+export interface CustomAggregation {
+  start: string
+  end: string
+  default: string
+}
+
+export const aggregationList = [
+  {
+    value: '-2',
+    text: '100'
+  },
+  {
+    value: '-1',
+    text: '10'
+  },
+  {
+    value: '0',
+    text: '1'
+  },
+  {
+    value: '1',
+    text: '0.1'
+  },
+  {
+    value: '2',
+    text: '0.01'
+  },
+  {
+    value: '3',
+    text: '0.001'
+  }
+]
+
+const getDecimalPlaceFromValue = (value: string) =>
+  aggregationList.find(({ text }) => text === value)?.value
+
+export const customAggregations = {
+  'BNB/USDT': {
+    start: getDecimalPlaceFromValue('10'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('1')
+  },
+  'BNB/USDT PERP': {
+    start: getDecimalPlaceFromValue('10'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('1')
+  },
+  'BTC/USDT': {
+    start: getDecimalPlaceFromValue('100'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('10')
+  },
+  'BTC/USDT PERP': {
+    start: getDecimalPlaceFromValue('100'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('10')
+  },
+  'WETH/USDT': {
+    start: getDecimalPlaceFromValue('10'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('1')
+  },
+  'WETH/USDT PERP': {
+    start: getDecimalPlaceFromValue('10'),
+    end: getDecimalPlaceFromValue('0.1'),
+    default: getDecimalPlaceFromValue('1')
+  }
+} as Record<string, CustomAggregation>

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -38,6 +38,7 @@ export const UI_DEFAULT_MAX_DISPLAY_DECIMALS = 6
 export const UI_DEFAULT_PRICE_DISPLAY_DECIMALS = 4
 export const UI_DEFAULT_AMOUNT_DISPLAY_DECIMALS = 4
 export const UI_DEFAULT_AGGREGATION_DECIMALS = 3
+export const UI_DEFAULT_AGGREGATION_DECIMALS_STRING = '3'
 
 export const NETWORK: Network = process.env.APP_NETWORK || Network.Testnet
 export const IS_TESTNET = [

--- a/components/partials/common/orderbook/aggregation-selector.vue
+++ b/components/partials/common/orderbook/aggregation-selector.vue
@@ -23,6 +23,7 @@
 import Vue from 'vue'
 import SelectorItem from '~/components/layout/selectors/selector-item.vue'
 import Dropdown from '~/components/elements/dropdown.vue'
+import { aggregationList } from '~/app/data/aggregation'
 
 export default Vue.extend({
   components: {
@@ -32,44 +33,29 @@ export default Vue.extend({
 
   props: {
     value: {
-      type: Number,
+      type: String,
       required: true
     },
 
     minTick: {
       type: Number,
       required: true
+    },
+
+    start: {
+      type: String,
+      default: null
+    },
+
+    end: {
+      type: String,
+      default: null
     }
   },
 
   data() {
     return {
-      list: [
-        {
-          value: -2,
-          text: '100'
-        },
-        {
-          value: -1,
-          text: '10'
-        },
-        {
-          value: 0,
-          text: '1'
-        },
-        {
-          value: 1,
-          text: '0.1'
-        },
-        {
-          value: 2,
-          text: '0.01'
-        },
-        {
-          value: 3,
-          text: '0.001'
-        }
-      ]
+      list: aggregationList
     }
   },
 
@@ -81,9 +67,16 @@ export default Vue.extend({
     },
 
     filteredList(): Record<string, any>[] {
-      const { minTick, list } = this
+      const { list, minTick, start, end } = this
 
-      const index = list.findIndex(({ value }) => value === minTick)
+      if (start && end) {
+        const startIndex = list.findIndex(({ value }) => value === start)
+        const endIndex = list.findIndex(({ value }) => value === end)
+
+        return list.slice(startIndex, endIndex + 1)
+      }
+
+      const index = list.findIndex(({ value }) => value === minTick.toString())
 
       return list.slice(Math.max(index - 2, 0), index + 1)
     }

--- a/components/partials/derivatives/orderbook.vue
+++ b/components/partials/derivatives/orderbook.vue
@@ -29,6 +29,8 @@
         class="pr-2"
         :min-tick="minTick"
         :value="aggregation"
+        :start="start"
+        :end="end"
         @click="handleAggregationChange"
       />
     </div>
@@ -37,7 +39,7 @@
       <component
         :is="component"
         v-if="component"
-        :aggregation="aggregation"
+        :aggregation="Number(aggregation)"
       ></component>
     </div>
   </div>
@@ -48,7 +50,11 @@ import Vue from 'vue'
 import Orderbook from './orderbook/index.vue'
 import Trades from './trades/index.vue'
 import AggregationSelector from '~/components/partials/common/orderbook/aggregation-selector.vue'
-import { UI_DEFAULT_AGGREGATION_DECIMALS } from '~/app/utils/constants'
+import {
+  UI_DEFAULT_AGGREGATION_DECIMALS,
+  UI_DEFAULT_AGGREGATION_DECIMALS_STRING
+} from '~/app/utils/constants'
+import { customAggregations } from '~/app/data/aggregation'
 
 const components = {
   orderbook: 'v-orderbook',
@@ -64,18 +70,26 @@ export default Vue.extend({
 
   data() {
     return {
-      aggregation: UI_DEFAULT_AGGREGATION_DECIMALS, // default aggregation decimal
+      aggregation: UI_DEFAULT_AGGREGATION_DECIMALS_STRING,
       minTick: UI_DEFAULT_AGGREGATION_DECIMALS,
       components,
-      component: components.orderbook
+      component: components.orderbook,
+      start: null as string | null,
+      end: null as string | null
     }
   },
 
   mounted() {
     const market = this.$accessor.derivatives.market
     if (market && market.priceDecimals) {
-      this.aggregation = market.priceDecimals
+      const customAggregation = customAggregations[market.ticker]
       this.minTick = market.priceDecimals
+
+      // applies custom aggregation base on pre configured settings
+      this.start = customAggregation?.start || null
+      this.end = customAggregation?.end || null
+      this.aggregation =
+        customAggregation?.default || market.priceDecimals.toString()
     }
   },
 
@@ -84,7 +98,7 @@ export default Vue.extend({
       this.component = component
     },
 
-    handleAggregationChange(aggregation: number) {
+    handleAggregationChange(aggregation: string) {
       this.aggregation = aggregation
     }
   }

--- a/components/partials/spot/orderbook.vue
+++ b/components/partials/spot/orderbook.vue
@@ -29,6 +29,8 @@
         class="pr-2"
         :min-tick="minTick"
         :value="aggregation"
+        :start="start"
+        :end="end"
         @click="handleAggregationChange"
       />
     </div>
@@ -37,7 +39,7 @@
       <component
         :is="component"
         v-if="component"
-        :aggregation="aggregation"
+        :aggregation="Number(aggregation)"
       ></component>
     </div>
   </div>
@@ -48,7 +50,11 @@ import Vue from 'vue'
 import Orderbook from './orderbook/index.vue'
 import Trades from './trades/index.vue'
 import AggregationSelector from '~/components/partials/common/orderbook/aggregation-selector.vue'
-import { UI_DEFAULT_AGGREGATION_DECIMALS } from '~/app/utils/constants'
+import {
+  UI_DEFAULT_AGGREGATION_DECIMALS,
+  UI_DEFAULT_AGGREGATION_DECIMALS_STRING
+} from '~/app/utils/constants'
+import { customAggregations } from '~/app/data/aggregation'
 
 const components = {
   orderbook: 'v-orderbook',
@@ -64,18 +70,26 @@ export default Vue.extend({
 
   data() {
     return {
-      aggregation: UI_DEFAULT_AGGREGATION_DECIMALS, // default aggregation decimal
+      aggregation: UI_DEFAULT_AGGREGATION_DECIMALS_STRING, // default aggregation decimal
       minTick: UI_DEFAULT_AGGREGATION_DECIMALS,
       components,
-      component: components.orderbook
+      component: components.orderbook,
+      start: null as string | null,
+      end: null as string | null
     }
   },
 
   mounted() {
     const market = this.$accessor.spot.market
     if (market && market.priceDecimals) {
-      this.aggregation = market.priceDecimals
+      const customAggregation = customAggregations[market.ticker]
       this.minTick = market.priceDecimals
+
+      // applies custom aggregation base on pre configured settings
+      this.start = customAggregation?.start || null
+      this.end = customAggregation?.end || null
+      this.aggregation =
+        customAggregation?.default || market.priceDecimals.toString()
     }
   },
 
@@ -84,7 +98,7 @@ export default Vue.extend({
       this.component = component
     },
 
-    handleAggregationChange(aggregation: number) {
+    handleAggregationChange(aggregation: string) {
       this.aggregation = aggregation
     }
   }


### PR DESCRIPTION
## This PR:
- set custom aggregation for bnb, btc and eth markets.
- resolves FE-2

## Screenshots:
| BTC aggregation list | BNB aggregation list | WETH aggregation list |
|-----|-----|-----|
| ![image](https://user-images.githubusercontent.com/10151054/142979136-a5e1a002-f994-485e-b80c-c028a9dffeb2.png) | ![image](https://user-images.githubusercontent.com/10151054/142979186-4dffac41-61ec-4112-abd3-583613144cb2.png) | ![image](https://user-images.githubusercontent.com/10151054/142984526-f2538f7b-1b97-46c2-b776-ddf729e4e63d.png) |

