### PR TITLE
feat: display total volume (24 hr) of markets on homepage

### DIFF
--- a/components/partials/common/markets/table.vue
+++ b/components/partials/common/markets/table.vue
@@ -46,6 +46,21 @@
           <span>{{ $t('futures') }}</span>
         </v-button>
       </div>
+
+      <span
+        v-if="totalVolume.gt(0)"
+        class="text-sm text-primary-500 mr-2 hidden sm:block"
+      >
+        {{ $t('total_market_volume_24h') }}: {{ totalVolumeToFormat }} USDT
+      </span>
+    </div>
+    <div>
+      <span
+        v-if="totalVolume.gt(0)"
+        class="text-sm text-primary-500 ml-2 mt-4 sm:hidden"
+      >
+        {{ $t('total_market_volume_24h') }}: {{ totalVolumeToFormat }} USDT
+      </span>
     </div>
     <div class="w-full mt-2">
       <v-search
@@ -119,6 +134,7 @@
 </template>
 
 <script lang="ts">
+import { BigNumberInBase } from '@injectivelabs/utils'
 import Vue, { PropType } from 'vue'
 import TableBody from '~/components/elements/table-body.vue'
 import TableHeader from '~/components/elements/table-header.vue'
@@ -131,6 +147,7 @@ import {
   UiSpotMarket,
   UiSpotMarketSummary
 } from '~/types'
+import { ZERO_IN_BASE } from '~/app/utils/constants'
 
 export interface UiMarketAndSummary {
   market: UiDerivativeMarket | UiSpotMarket
@@ -203,6 +220,21 @@ export default Vue.extend({
             marketTypeCondition
           )
         }) as UiMarketAndSummary[]
+    },
+
+    totalVolume(): BigNumberInBase {
+      const { filteredMarkets } = this
+
+      return filteredMarkets.reduce(
+        (total, { summary }) => total.plus(summary.volume || ZERO_IN_BASE),
+        ZERO_IN_BASE
+      )
+    },
+
+    totalVolumeToFormat(): string {
+      const { totalVolume } = this
+
+      return totalVolume.toFormat(0, BigNumberInBase.ROUND_DOWN)
     }
   },
 

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -30,6 +30,7 @@ export default {
   last_traded_price: 'Last Traded Price',
   last_traded_price_tooltip: 'The last price at which a trade occurred.',
   market_change_24h: 'Change (24h)',
+  total_market_volume_24h: 'Total Volume (24H)',
   market_change_24h_tooltip: 'The change in price over the past 24 hours.',
   market_volume_24h: 'Volume (24h)',
   market_volume_24h_tooltip: 'The total trade volume over the past 24 hours.',


### PR DESCRIPTION
## This PR:
- more information [here](https://linear.app/injective/issue/FE-282/dex-homepage-markets-display-daily-volume-of-all-markets) 
- resolves FE-282

## Screenshot:
![image](https://user-images.githubusercontent.com/10151054/143391286-c092fe0f-95a0-4a5c-8d0b-1bb8ff506c09.png)
