### PR TITLE
fix: reward points for BNB/USDT perp always shows zero

### DIFF
--- a/components/partials/derivatives/trading/trade.vue
+++ b/components/partials/derivatives/trading/trade.vue
@@ -1184,11 +1184,11 @@ export default Vue.extend({
       const multipliersList = tradingRewardsCampaign.tradingRewardCampaignInfo
         .tradingRewardBoostInfo
         ? tradingRewardsCampaign.tradingRewardCampaignInfo
-            .tradingRewardBoostInfo.spotMarketMultipliersList
+            .tradingRewardBoostInfo.derivativeMarketMultipliersList
         : []
 
       const boosted = boostedList.findIndex(
-        (spotMarketId) => spotMarketId === market.marketId
+        (derivativeMarketId) => derivativeMarketId === market.marketId
       )
 
       const boostedMultiplier =
@@ -1242,11 +1242,11 @@ export default Vue.extend({
       const multipliersList = tradingRewardsCampaign.tradingRewardCampaignInfo
         .tradingRewardBoostInfo
         ? tradingRewardsCampaign.tradingRewardCampaignInfo
-            .tradingRewardBoostInfo.spotMarketMultipliersList
+            .tradingRewardBoostInfo.derivativeMarketMultipliersList
         : []
 
       const boosted = boostedList.findIndex(
-        (spotMarketId) => spotMarketId === market.marketId
+        (derivativeMarketId) => derivativeMarketId === market.marketId
       )
       const boostedMultiplier =
         boosted >= 0


### PR DESCRIPTION
## This PR:
- resolves #441 
- resolves FE-293

## Screenshot:
![image](https://user-images.githubusercontent.com/10151054/143989324-17138fe5-0f74-48b6-99df-417f477d1e98.png)
