### PR TITLE
fix: missing token balances on port folio page trading account holding section

### DIFF
--- a/app/services/tokens.ts
+++ b/app/services/tokens.ts
@@ -8,6 +8,7 @@ import { fetchDenomTrace } from './ibc'
 import { TxProvider } from '~/app/providers/TxProvider'
 import { peggyDenomToContractAddress } from '~/app/transformers/peggy'
 import { coinGeckoConsumer } from '~/app/singletons/CoinGeckoConsumer'
+import { explorerCoinGeckoConsumer } from '~/app/singletons/ExplorerCoinGeckoConsumer'
 import { getContracts } from '~/app/singletons/Contracts'
 import {
   CHAIN_ID,
@@ -123,6 +124,20 @@ export const getUsdtTokenPriceFromCoinGecko = async (coinId: string) => {
   }
 
   return new BigNumberInBase(currentPrice.usd).toNumber()
+}
+
+export const getUsdTokensPriceFromExplorerCoinGecko = async (
+  coinIds: string
+) => {
+  if (!coinIds) {
+    return []
+  }
+
+  const {
+    data: { data }
+  } = await explorerCoinGeckoConsumer.fetchCoins(coinIds)
+
+  return data
 }
 
 export const setTokenAllowance = async ({

--- a/app/singletons/ExplorerCoinGeckoConsumer.ts
+++ b/app/singletons/ExplorerCoinGeckoConsumer.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@injectivelabs/utils'
+import { app } from '../singletons/App'
+
+export class ExplorerCoinGeckoConsumer {
+  private httpClient: HttpClient
+
+  constructor({ baseUrl }: { baseUrl: string }) {
+    this.httpClient = new HttpClient(`${baseUrl}/explorer/v1/`)
+  }
+
+  async fetchCoins(ids: string) {
+    return (await this.httpClient.get('coin-price', {
+      coinIds: ids
+    })) as {
+      data: {
+        data: [
+          {
+            id: string
+            symbol: string
+            name: string
+            // eslint-disable-next-line camelcase
+            current_price: string
+          }
+        ]
+      }
+    }
+  }
+}
+
+export const explorerCoinGeckoConsumer = new ExplorerCoinGeckoConsumer({
+  baseUrl: app.appUrlEndpoint.baseUrl
+})

--- a/store/portfolio.ts
+++ b/store/portfolio.ts
@@ -169,6 +169,7 @@ export const actions = actionTree(
       await this.app.$accessor.portfolio.fetchDerivativeOrderbooks()
       await this.app.$accessor.portfolio.streamOrderbooks()
       await this.app.$accessor.portfolio.streamSubaccountOrders()
+      await this.app.$accessor.account.fetchSubaccountsBalances()
       await this.app.$accessor.token.getAllTokenWithBalanceAndAllowance()
       await this.app.$accessor.bank.fetchBalances()
       await this.app.$accessor.token.getAllTokenWithBalanceAndAllowance()


### PR DESCRIPTION
## This PR:
- resolves #450 
- resolves FE-294
- the root cause of the issue is that we are relying on the bank balances data to retrieve the token metadata to reflect them in the subaccount page for optimization purposes, for example, if the user is holding ATOM in the subaccount but not on the injective chain (bank account). We won't be able to retrieve the tokenMeta data hence they are not displayed.
- I've added the logic to retrieve the sub balances token metadata only on the portfolio page load separately using the `api/explorer/v1/coin-price` API endpoint.

## Screenshot:
![image](https://user-images.githubusercontent.com/10151054/144023825-00b2f560-406d-4292-8918-3704f01ec556.png)

