### PR TITLE
fix: dex market order input - min quantity tick size validation

### DIFF
--- a/app/data/aggregation.ts
+++ b/app/data/aggregation.ts
@@ -27,6 +27,10 @@ export const aggregationList = [
   {
     value: '3',
     text: '0.001'
+  },
+  {
+    value: '4',
+    text: '0.0001'
   }
 ]
 

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -51,7 +51,8 @@ export const isNumericKeycode = (keyCode?: number) =>
   keyCode &&
   ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
 
-export const isDotKeycode = (keyCode?: number) => keyCode && keyCode === 190
+export const isDotKeycode = (keyCode?: number) =>
+  keyCode && (keyCode === 190 || keyCode === 110)
 
 export const getDecimalsFromNumber = (number: number | string): number => {
   const numberToBn = new BigNumber(number).toNumber()

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -47,12 +47,18 @@ export const getDecimalsBasedOnNumber = (
   }
 }
 
+export const isNumericKeycode = (keyCode?: number) =>
+  keyCode &&
+  ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
+
+export const isDotKeycode = (keyCode?: number) => keyCode && keyCode === 190
+
 export const getDecimalsFromNumber = (number: number | string): number => {
   const numberToBn = new BigNumber(number).toNumber()
   const numberParts = numberToBn.toString().split('.')
   const [, decimals] = numberParts
 
-  const actualDecimals = decimals ? decimals.length : 1
+  const actualDecimals = decimals ? decimals.length : 0
 
   return actualDecimals > UI_DEFAULT_MAX_DISPLAY_DECIMALS
     ? UI_DEFAULT_MAX_DISPLAY_DECIMALS

--- a/components/inputs/input.vue
+++ b/components/inputs/input.vue
@@ -40,6 +40,7 @@
             'input-small': small
           }"
           @blur="handleBlur"
+          @keydown="handleKeydown"
           @input="handleChangeOnInput"
           @wheel="$event.target.blur()"
         />
@@ -209,6 +210,10 @@ export default Vue.extend({
 
     handleBlur() {
       this.$emit('blur')
+    },
+
+    handleKeydown(event: DOMEvent<HTMLInputElement>) {
+      this.$emit('keydown', event)
     },
 
     handleMaxSelector() {

--- a/components/partials/derivatives/trading/trade.vue
+++ b/components/partials/derivatives/trading/trade.vue
@@ -56,6 +56,7 @@
           min="0"
           @blur="onAmountBlur"
           @input="onAmountChange"
+          @keydown="onAmountKeydown"
           @input-max="() => onMaxInput(100)"
         >
           <span slot="addon">{{ market.baseToken.symbol.toUpperCase() }}</span>
@@ -208,6 +209,7 @@ import ButtonCheckbox from '~/components/inputs/button-checkbox.vue'
 import VModalOrderConfirm from '~/components/partials/modals/order-confirm.vue'
 import {
   DerivativeOrderSide,
+  DOMEvent,
   TradeExecutionType,
   UiDerivativeOrderbook,
   UiPriceLevel,
@@ -230,6 +232,11 @@ import {
   FeeDiscountAccountInfo
 } from '~/types/exchange'
 import { cosmosSdkDecToBigNumber } from '~/app/transformers'
+import {
+  getDecimalsFromNumber,
+  isDotKeycode,
+  isNumericKeycode
+} from '~/app/utils/helpers'
 
 interface TradeForm {
   reduceOnly: boolean
@@ -1499,8 +1506,32 @@ export default Vue.extend({
       }
 
       this.form.amount = new BigNumberInBase(form.amount || 0).toFixed(
-        market.quantityDecimals
+        market.quantityDecimals,
+        BigNumberInBase.ROUND_DOWN
       )
+    },
+
+    onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
+      const { market, form } = this
+
+      if (!market) {
+        return
+      }
+
+      // prevent dot for quantity decimals 0
+      if (market.quantityDecimals === 0 && isDotKeycode(event.keyCode)) {
+        event.preventDefault()
+
+        return
+      }
+
+      if (
+        getDecimalsFromNumber(form.amount) === market.quantityDecimals &&
+        isNumericKeycode(event.keyCode) &&
+        market.quantityDecimals !== 0
+      ) {
+        event.preventDefault()
+      }
     },
 
     onAmountChange(amount: string = '') {

--- a/components/partials/derivatives/trading/trade.vue
+++ b/components/partials/derivatives/trading/trade.vue
@@ -1518,18 +1518,14 @@ export default Vue.extend({
         return
       }
 
-      // prevent dot for quantity decimals 0
-      if (market.quantityDecimals === 0 && isDotKeycode(event.keyCode)) {
-        event.preventDefault()
-
-        return
-      }
-
-      if (
+      const inputIsDotQuantityDecimalZero =
+        market.quantityDecimals === 0 && isDotKeycode(event.keyCode)
+      const inputDecimalExceedQuantityDecimal =
         getDecimalsFromNumber(form.amount) === market.quantityDecimals &&
         isNumericKeycode(event.keyCode) &&
         market.quantityDecimals !== 0
-      ) {
+
+      if (inputIsDotQuantityDecimalZero || inputDecimalExceedQuantityDecimal) {
         event.preventDefault()
       }
     },

--- a/components/partials/spot/trading/trade.vue
+++ b/components/partials/spot/trading/trade.vue
@@ -56,6 +56,7 @@
           min="0"
           @blur="onAmountBlur"
           @input="onAmountChange"
+          @keydown="onAmountKeydown"
           @input-max="() => onMaxInput(100)"
         >
           <span slot="addon">{{ market.baseToken.symbol.toUpperCase() }}</span>
@@ -162,7 +163,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import { TradeError } from 'types/errors'
-import { BigNumberInWei, Status, BigNumberInBase } from '@injectivelabs/utils'
+import {
+  BigNumberInWei,
+  Status,
+  BigNumberInBase
+} from '@injectivelabs/utils'
 import OrderDetails from './order-details.vue'
 import OrderDetailsMarket from './order-details-market.vue'
 import {
@@ -177,6 +182,7 @@ import {
 import ButtonCheckbox from '~/components/inputs/button-checkbox.vue'
 import VModalOrderConfirm from '~/components/partials/modals/order-confirm.vue'
 import {
+  DOMEvent,
   SpotOrderSide,
   TradeExecutionType,
   UiSpotOrderbook,
@@ -194,6 +200,11 @@ import {
   FeeDiscountAccountInfo,
   TradingRewardsCampaign
 } from '~/types/exchange'
+import {
+  getDecimalsFromNumber,
+  isDotKeycode,
+  isNumericKeycode
+} from '~/app/utils/helpers'
 
 interface TradeForm {
   amount: string
@@ -1208,8 +1219,32 @@ export default Vue.extend({
       }
 
       this.form.amount = new BigNumberInBase(form.amount || 0).toFixed(
-        market.quantityDecimals
+        market.quantityDecimals,
+        BigNumberInBase.ROUND_DOWN
       )
+    },
+
+    onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
+      const { market, form } = this
+
+      if (!market) {
+        return
+      }
+
+      // prevent dot for quantity decimals 0
+      if (market.quantityDecimals === 0 && isDotKeycode(event.keyCode)) {
+        event.preventDefault()
+
+        return
+      }
+
+      if (
+        getDecimalsFromNumber(form.amount) === market.quantityDecimals &&
+        isNumericKeycode(event.keyCode) &&
+        market.quantityDecimals !== 0
+      ) {
+        event.preventDefault()
+      }
     },
 
     onAmountChange(amount: string = '') {

--- a/components/partials/spot/trading/trade.vue
+++ b/components/partials/spot/trading/trade.vue
@@ -163,11 +163,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { TradeError } from 'types/errors'
-import {
-  BigNumberInWei,
-  Status,
-  BigNumberInBase
-} from '@injectivelabs/utils'
+import { BigNumberInWei, Status, BigNumberInBase } from '@injectivelabs/utils'
 import OrderDetails from './order-details.vue'
 import OrderDetailsMarket from './order-details-market.vue'
 import {
@@ -1231,18 +1227,14 @@ export default Vue.extend({
         return
       }
 
-      // prevent dot for quantity decimals 0
-      if (market.quantityDecimals === 0 && isDotKeycode(event.keyCode)) {
-        event.preventDefault()
-
-        return
-      }
-
-      if (
+      const inputIsDotQuantityDecimalZero =
+        market.quantityDecimals === 0 && isDotKeycode(event.keyCode)
+      const inputDecimalExceedQuantityDecimal =
         getDecimalsFromNumber(form.amount) === market.quantityDecimals &&
         isNumericKeycode(event.keyCode) &&
         market.quantityDecimals !== 0
-      ) {
+
+      if (inputIsDotQuantityDecimalZero || inputDecimalExceedQuantityDecimal) {
         event.preventDefault()
       }
     },

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,7 @@ import { BigNumberInBase, BigNumberInWei } from '@injectivelabs/utils'
 
 export interface DOMEvent<T extends EventTarget> extends Event {
   target: T
+  keyCode?: number
 }
 
 export interface Constructable<T> {


### PR DESCRIPTION
## This PR:
- resolves FE-331 [linear](https://linear.app/injective/issue/FE-331/dex-market-order-input-min-quantity-tick-size-validation)
