### PR TITLE
chore: hardcode dmm names for selected addresses

### DIFF
--- a/app/data/dmm.ts
+++ b/app/data/dmm.ts
@@ -1,0 +1,6 @@
+export const hardCodedDmmNames = {
+  inj1qe8upydvr472gt4p8n35q4ym2z0xr9ttd0raqz: 'Ledger Prime 1',
+  inj1x2ck0ql2ngyxqtw8jteyc0tchwnwxv7npaungt: 'Anti Capital 1 ',
+  inj1yzmv3utcm0xx4ahsn7lyew0zzdjp4z7wlx44vx: 'Anti Capital 2 ',
+  inj1rwv4zn3jptsqs7l8lpa3uvzhs57y8duemete9e: 'Anti Capital 3 '
+} as Record<string, string>

--- a/app/services/dmm.ts
+++ b/app/services/dmm.ts
@@ -31,18 +31,24 @@ export const fetchDMMRecords = async ({
   dmmName?: string
   epochId?: string
 }) => {
-  const promise = dmmConsumer.fetchDMMRecords({
-    accountAddress,
-    dmmName,
-    epochId
-  })
+  try {
+    const promise = dmmConsumer.fetchDMMRecords({
+      accountAddress,
+      dmmName,
+      epochId
+    })
 
-  const dmmRecords = await metricsProvider.sendAndRecord(
-    promise,
-    DMMMetrics.FetchDMMRecords
-  )
+    const dmmRecords = await metricsProvider.sendAndRecord(
+      promise,
+      DMMMetrics.FetchDMMRecords
+    )
 
-  return dmmRecords.map(DMMTransformer.grpcEpochResultRecordToEpochResultRecord)
+    return dmmRecords.map(
+      DMMTransformer.grpcEpochResultRecordToEpochResultRecord
+    )
+  } catch (e: any) {
+    throw new Error(e.message)
+  }
 }
 
 export const fetchEpochs = async () => {

--- a/components/partials/dmm/history/index.vue
+++ b/components/partials/dmm/history/index.vue
@@ -14,7 +14,7 @@
               <h3
                 class="text-gray-200 text-base sm:text-lg md:text-2xl mt-3 break-all"
               >
-                {{ injectiveAddress }}
+                {{ dmmDisplayName }}
               </h3>
 
               <VHistoryTable class="mt-6" />
@@ -43,6 +43,7 @@ import { Status, StatusType } from '@injectivelabs/utils'
 import VHistoryTable from './history-table.vue'
 import HOCLoading from '~/components/hoc/loading.vue'
 import { UiDmmMarketMaker } from '~/types'
+import { hardCodedDmmNames } from '~/app/data/dmm'
 
 export default Vue.extend({
   components: {
@@ -67,6 +68,12 @@ export default Vue.extend({
 
     marketMakers(): UiDmmMarketMaker[] {
       return this.$accessor.dmm.marketMakers
+    },
+
+    dmmDisplayName(): string {
+      const { injectiveAddress } = this
+
+      return hardCodedDmmNames[injectiveAddress] || injectiveAddress
     },
 
     dmmName(): string | undefined {

--- a/components/partials/dmm/ranking/elcs-row.vue
+++ b/components/partials/dmm/ranking/elcs-row.vue
@@ -49,6 +49,8 @@ import Vue, { PropType } from 'vue'
 import { formatWalletAddress } from '@injectivelabs/utils'
 import TableRow from '~/components/elements/table-row.vue'
 import { UIEpochMarketELCSItem } from '~/types'
+import { hardCodedDmmNames } from '~/app/data/dmm'
+
 export default Vue.extend({
   components: {
     TableRow
@@ -68,12 +70,24 @@ export default Vue.extend({
     }
   },
   computed: {
-    formattedAddress(): string {
+    hardcodedName(): string {
       const { item } = this
+
       if (!item.address) {
         return ''
       }
-      return formatWalletAddress(item.address)
+
+      return hardCodedDmmNames[item.address] || ''
+    },
+
+    formattedAddress(): string {
+      const { item, hardcodedName } = this
+
+      if (!item.address) {
+        return ''
+      }
+
+      return hardcodedName !== '' ? hardcodedName : formatWalletAddress(item.address)
     }
   }
 })

--- a/components/partials/dmm/ranking/evcs-row.vue
+++ b/components/partials/dmm/ranking/evcs-row.vue
@@ -44,6 +44,7 @@ import Vue, { PropType } from 'vue'
 import { formatWalletAddress } from '@injectivelabs/utils'
 import TableRow from '~/components/elements/table-row.vue'
 import { UIEpochMarketEVCSItem } from '~/types'
+import { hardCodedDmmNames } from '~/app/data/dmm'
 
 export default Vue.extend({
   components: {
@@ -68,14 +69,26 @@ export default Vue.extend({
   },
 
   computed: {
-    formattedAddress(): string {
+    hardcodedName(): string {
       const { item } = this
 
       if (!item.address) {
         return ''
       }
 
-      return formatWalletAddress(item.address)
+      return hardCodedDmmNames[item.address] || ''
+    },
+
+    formattedAddress(): string {
+      const { item, hardcodedName } = this
+
+      if (!item.address) {
+        return ''
+      }
+
+      return hardcodedName !== ''
+        ? hardcodedName
+        : formatWalletAddress(item.address)
     }
   }
 })

--- a/components/partials/dmm/summary/table-row.vue
+++ b/components/partials/dmm/summary/table-row.vue
@@ -65,6 +65,7 @@ import Vue, { PropType } from 'vue'
 import { formatWalletAddress } from '@injectivelabs/utils'
 import TableRow from '~/components/elements/table-row.vue'
 import { UiEpochSummaryItem } from '~/types'
+import { hardCodedDmmNames } from '~/app/data/dmm'
 
 export default Vue.extend({
   components: {
@@ -94,14 +95,24 @@ export default Vue.extend({
   },
 
   computed: {
-    formattedAddress(): string {
+    hardcodedName(): string {
       const { item } = this
 
       if (!item.address) {
         return ''
       }
 
-      return formatWalletAddress(item.address)
+      return hardCodedDmmNames[item.address] || ''
+    },
+
+    formattedAddress(): string {
+      const { item, hardcodedName } = this
+
+      if (!item.address) {
+        return ''
+      }
+
+      return hardcodedName !== '' ? hardcodedName : formatWalletAddress(item.address)
     }
   }
 })

--- a/store/dmm.ts
+++ b/store/dmm.ts
@@ -144,7 +144,9 @@ export const actions = actionTree(
         epochId: activeEpochId
       })
 
-      commit('setRecords', records)
+      if (records) {
+        commit('setRecords', records)
+      }
     },
 
     async fetchEpochs({ commit }) {


### PR DESCRIPTION
## This PR:
- hardcode dmm names for selected addresses
- prevent error toast from printing `dmm [inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku] didn't participate in the epoch [epoch_211228_220124]` messages