### PR TITLE
feat: disable scientific notation in numeric fields

### DIFF
--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -49,13 +49,6 @@ export const getDecimalsBasedOnNumber = (
   }
 }
 
-export const isNumericKeycode = (keyCode?: number) =>
-  keyCode &&
-  ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
-
-export const isDotKeycode = (keyCode?: number) =>
-  keyCode && (keyCode === 190 || keyCode === 110)
-
 export const getExactDecimalsFromNumber = (number: number | string): number => {
   if (Number(number) % 1 !== 0) {
     const [, decimals] = number.toString().split('.')

--- a/app/utils/input.ts
+++ b/app/utils/input.ts
@@ -1,0 +1,35 @@
+import { getExactDecimalsFromNumber } from './helpers'
+
+export const isNumericKeycode = (keyCode?: number) =>
+  keyCode &&
+  ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
+
+export const passNumericInputValidation = (
+  keyCode: string,
+  additionalInvalidChars: string[] = []
+): boolean => {
+  const invalidChars = ['-', '+', 'e']
+
+  return ![...invalidChars, ...additionalInvalidChars].includes(keyCode)
+}
+
+export const hasLessThenLimitedDecimalPlaces = (
+  value: string,
+  limitedDecimalPlaces: number
+) => {
+  const valueDecimalPlaces = getExactDecimalsFromNumber(value)
+
+  return valueDecimalPlaces < limitedDecimalPlaces
+}
+
+export const hasLessThenDpAndKeyCodeIsNumeric = ({
+  value,
+  decimalPlaces,
+  keyCode
+}: {
+  value: string
+  decimalPlaces: number
+  keyCode: number
+}) =>
+  !hasLessThenLimitedDecimalPlaces(value, decimalPlaces) &&
+  isNumericKeycode(keyCode)

--- a/app/utils/input.ts
+++ b/app/utils/input.ts
@@ -1,35 +1,60 @@
 import { getExactDecimalsFromNumber } from './helpers'
+import { DOMEvent } from '~/types'
 
 export const isNumericKeycode = (keyCode?: number) =>
   keyCode &&
   ((keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105))
 
 export const passNumericInputValidation = (
-  keyCode: string,
+  event: DOMEvent<HTMLInputElement>,
   additionalInvalidChars: string[] = []
 ): boolean => {
+  if (!event.key) {
+    return true
+  }
+
   const invalidChars = ['-', '+', 'e']
 
-  return ![...invalidChars, ...additionalInvalidChars].includes(keyCode)
+  return ![...invalidChars, ...additionalInvalidChars].includes(event.key)
 }
 
 export const hasLessThenLimitedDecimalPlaces = (
   value: string,
   limitedDecimalPlaces: number
-) => {
+): boolean => {
   const valueDecimalPlaces = getExactDecimalsFromNumber(value)
 
   return valueDecimalPlaces < limitedDecimalPlaces
 }
 
-export const hasLessThenDpAndKeyCodeIsNumeric = ({
+export const inputTextIsHighlighted = (
+  event: DOMEvent<HTMLInputElement>
+): boolean => {
+  if (!event.view) {
+    return false
+  }
+
+  const highlightedText = event.view.getSelection().toString()
+
+  return highlightedText.trim() !== ''
+}
+
+export const hasMoreThenDpAndKeyCodeIsNumeric = ({
   value,
   decimalPlaces,
-  keyCode
+  event
 }: {
   value: string
   decimalPlaces: number
-  keyCode: number
-}) =>
-  !hasLessThenLimitedDecimalPlaces(value, decimalPlaces) &&
-  isNumericKeycode(keyCode)
+  event: DOMEvent<HTMLInputElement>
+}) => {
+  if (!event || !event.keyCode || !event.key) {
+    return true
+  }
+
+  return (
+    !inputTextIsHighlighted(event) &&
+    !hasLessThenLimitedDecimalPlaces(value, decimalPlaces) &&
+    isNumericKeycode(event.keyCode)
+  )
+}

--- a/components/inputs/input.vue
+++ b/components/inputs/input.vue
@@ -93,6 +93,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 import { DOMEvent } from '~/types'
+import { passNumericInputValidation } from '~/app/utils/input'
 
 export default Vue.extend({
   inheritAttrs: false,
@@ -234,7 +235,15 @@ export default Vue.extend({
     },
 
     handleKeydown(event: DOMEvent<HTMLInputElement>) {
-      this.$emit('keydown', event)
+      if (
+        event.key &&
+        !passNumericInputValidation(event.key) &&
+        event.target.type === 'number'
+      ) {
+        event.preventDefault()
+      } else {
+        this.$emit('keydown', event)
+      }
     },
 
     handleMaxSelector() {

--- a/components/inputs/input.vue
+++ b/components/inputs/input.vue
@@ -236,8 +236,7 @@ export default Vue.extend({
 
     handleKeydown(event: DOMEvent<HTMLInputElement>) {
       if (
-        event.key &&
-        !passNumericInputValidation(event.key) &&
+        !passNumericInputValidation(event) &&
         event.target.type === 'number'
       ) {
         event.preventDefault()

--- a/components/layout/wallet/wallet.vue
+++ b/components/layout/wallet/wallet.vue
@@ -22,7 +22,7 @@
 
     <VPopperBox
       ref="popper-wallet"
-      class="popper bg-gray-800 rounded flex flex-col flex-wrap absolute min-w-[356px] z-10 shadow"
+      class="popper bg-gray-800 rounded flex flex-col flex-wrap absolute min-w-[356px] z-10 shadow-md"
       binding-element="#wallet-address"
       :options="popperOption"
     >

--- a/components/partials/derivatives/trading/trade.vue
+++ b/components/partials/derivatives/trading/trade.vue
@@ -231,7 +231,7 @@ import {
   FeeDiscountAccountInfo
 } from '~/app/services/exchange'
 import {
-  hasLessThenDpAndKeyCodeIsNumeric,
+  hasMoreThenDpAndKeyCodeIsNumeric,
   passNumericInputValidation
 } from '~/app/utils/input'
 import { excludedPriceDeviationSlugs } from '~/app/data/market'
@@ -1544,18 +1544,18 @@ export default Vue.extend({
     onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
       const { market, form } = this
 
-      if (!market || !event.keyCode || !event.key) {
+      if (!market) {
         return
       }
 
       const disableDot = market.quantityDecimals === 0
 
       if (
-        !passNumericInputValidation(event.key, disableDot ? ['.'] : []) ||
-        hasLessThenDpAndKeyCodeIsNumeric({
+        !passNumericInputValidation(event, disableDot ? ['.'] : []) ||
+        hasMoreThenDpAndKeyCodeIsNumeric({
+          event,
           value: form.amount,
-          decimalPlaces: market.quantityDecimals,
-          keyCode: event.keyCode
+          decimalPlaces: market.quantityDecimals
         })
       ) {
         event.preventDefault()
@@ -1570,10 +1570,10 @@ export default Vue.extend({
       }
 
       if (
-        hasLessThenDpAndKeyCodeIsNumeric({
+        hasMoreThenDpAndKeyCodeIsNumeric({
+          event,
           value: form.price,
-          decimalPlaces: market.quoteToken.decimals,
-          keyCode: event.keyCode
+          decimalPlaces: market.quoteToken.decimals
         })
       ) {
         event.preventDefault()

--- a/components/partials/modals/bridge/confirm.vue
+++ b/components/partials/modals/bridge/confirm.vue
@@ -134,7 +134,7 @@
             <v-button
               lg
               primary
-              class="w-full xs:w-1/2 font-bold"
+              class="w-full xs:w-2/3 font-bold"
               :disabled="buttonConfirmationDisabled"
               :status="status"
               @click="handlerFunction"

--- a/components/partials/portfolio/bridge/token-selector/select.vue
+++ b/components/partials/portfolio/bridge/token-selector/select.vue
@@ -108,10 +108,7 @@ import {
 } from '@injectivelabs/ui-common'
 import VTokenSelectorItem from './item.vue'
 import { DOMEvent } from '~/types'
-import {
-  getExactDecimalsFromNumber,
-  isNumericKeycode
-} from '~/app/utils/helpers'
+import { hasLessThenDpAndKeyCodeIsNumeric } from '~/app/utils/input'
 import { UI_DEFAULT_DISPLAY_DECIMALS } from '~/app/utils/constants'
 
 export default Vue.extend({
@@ -260,12 +257,17 @@ export default Vue.extend({
     onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
       const { amount, value } = this
 
-      const allowedDecimalPlaces = value.decimals
-      const amountDecimalExceedTokenDecimal =
-        getExactDecimalsFromNumber(amount) === allowedDecimalPlaces &&
-        isNumericKeycode(event.keyCode)
+      if (!value.decimals || !event.keyCode) {
+        return false
+      }
 
-      if (amountDecimalExceedTokenDecimal) {
+      if (
+        hasLessThenDpAndKeyCodeIsNumeric({
+          value: amount,
+          decimalPlaces: value.decimals,
+          keyCode: event.keyCode
+        })
+      ) {
         event.preventDefault()
       }
     },

--- a/components/partials/portfolio/bridge/token-selector/select.vue
+++ b/components/partials/portfolio/bridge/token-selector/select.vue
@@ -108,7 +108,7 @@ import {
 } from '@injectivelabs/ui-common'
 import VTokenSelectorItem from './item.vue'
 import { DOMEvent } from '~/types'
-import { hasLessThenDpAndKeyCodeIsNumeric } from '~/app/utils/input'
+import { hasMoreThenDpAndKeyCodeIsNumeric } from '~/app/utils/input'
 import { UI_DEFAULT_DISPLAY_DECIMALS } from '~/app/utils/constants'
 
 export default Vue.extend({
@@ -257,15 +257,15 @@ export default Vue.extend({
     onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
       const { amount, value } = this
 
-      if (!value.decimals || !event.keyCode) {
+      if (!value.decimals) {
         return false
       }
 
       if (
-        hasLessThenDpAndKeyCodeIsNumeric({
+        hasMoreThenDpAndKeyCodeIsNumeric({
+          event,
           value: amount,
-          decimalPlaces: value.decimals,
-          keyCode: event.keyCode
+          decimalPlaces: value.decimals
         })
       ) {
         event.preventDefault()

--- a/components/partials/spot/trading/trade.vue
+++ b/components/partials/spot/trading/trade.vue
@@ -196,7 +196,7 @@ import {
   TradingRewardsCampaign
 } from '~/app/services/exchange'
 import {
-  hasLessThenDpAndKeyCodeIsNumeric,
+  hasMoreThenDpAndKeyCodeIsNumeric,
   passNumericInputValidation
 } from '~/app/utils/input'
 import { excludedPriceDeviationSlugs } from '~/app/data/market'
@@ -1225,18 +1225,18 @@ export default Vue.extend({
     onAmountKeydown(event: DOMEvent<HTMLInputElement>) {
       const { market, form } = this
 
-      if (!market || !event.keyCode || !event.key) {
+      if (!market) {
         return
       }
 
       const disableDot = market.quantityDecimals === 0
 
       if (
-        !passNumericInputValidation(event.key, disableDot ? ['.'] : []) ||
-        hasLessThenDpAndKeyCodeIsNumeric({
+        !passNumericInputValidation(event, disableDot ? ['.'] : []) ||
+        hasMoreThenDpAndKeyCodeIsNumeric({
+          event,
           value: form.amount,
-          decimalPlaces: market.quantityDecimals,
-          keyCode: event.keyCode
+          decimalPlaces: market.quantityDecimals
         })
       ) {
         event.preventDefault()
@@ -1246,15 +1246,15 @@ export default Vue.extend({
     onPriceKeyDown(event: DOMEvent<HTMLInputElement>) {
       const { market, form } = this
 
-      if (!market || !event.keyCode) {
+      if (!market) {
         return
       }
 
       if (
-        hasLessThenDpAndKeyCodeIsNumeric({
+        hasMoreThenDpAndKeyCodeIsNumeric({
+          event,
           value: form.price,
-          decimalPlaces: market.quoteToken.decimals,
-          keyCode: event.keyCode
+          decimalPlaces: market.quoteToken.decimals
         })
       ) {
         event.preventDefault()

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,9 @@ export interface DOMEvent<T extends EventTarget> extends Event {
   target: T
   keyCode?: number
   key?: string
+  view?: {
+    getSelection: Function
+  }
 }
 
 export interface Constructable<T> {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,7 @@
 export interface DOMEvent<T extends EventTarget> extends Event {
   target: T
   keyCode?: number
+  key?: string
 }
 
 export interface Constructable<T> {


### PR DESCRIPTION
## This PR:
- resolves [FE-498](https://linear.app/injective/issue/FE-498/do-not-allow-scientific-notation-in-numeric-fields-or-handle-it-more)
- resolves [FE-499](https://linear.app/injective/issue/FE-499/impossible-to-overwrite-buy-amount-in-limit-trade)
- refactor numeric input key-up validation implementation