### PR TITLE
feat: implement standalone markets page business logic

### DIFF
--- a/app/data/market.ts
+++ b/app/data/market.ts
@@ -37,6 +37,8 @@ export const newMarketsSlug = [
   'ust-usdt'
 ]
 
+export const innovationMarketsSlug = ['ape-usdt', 'huahua-usdt', 'gf-usdt']
+
 export const excludedPriceDeviationSlugs = ['bayc-weth-perp'] as string[]
 
 export const upcomingMarkets = [

--- a/components/elements/empty-list.vue
+++ b/components/elements/empty-list.vue
@@ -1,12 +1,14 @@
 <template>
   <div
-    class="bg-gray-900 h-full w-full flex flex-col items-center justify-center"
+    class="h-full w-full flex flex-col items-center justify-center"
+    :class="wrapperClass"
   >
-    <img src="/svg/empty-list.svg" class="mx-auto mb-2" />
-    <p>
-      <slot></slot>
+    <img src="/svg/empty-list.svg" class="mx-auto mb-3" />
+    <p class="text-sm">
       {{ message }}
     </p>
+
+    <slot />
   </div>
 </template>
 
@@ -16,9 +18,13 @@ import Vue from 'vue'
 export default Vue.extend({
   props: {
     message: {
-      required: false,
       type: String,
       default: ''
+    },
+
+    wrapperClass: {
+      type: String,
+      default: 'bg-gray-900'
     }
   }
 })

--- a/components/elements/table-body.vue
+++ b/components/elements/table-body.vue
@@ -7,7 +7,7 @@
     <div
       v-if="showEmpty"
       class="col-span-1 px-6 text-sm py-4 text-gray-200 items-center rounded-sm"
-      :class="[light ? 'bg-gray-850 rounded' : 'bg-gray-900']"
+      :class="{ 'bg-gray-850 rounded': light, 'bg-gray-900': !light }"
     >
       <slot name="empty" />
     </div>

--- a/components/elements/table-body.vue
+++ b/components/elements/table-body.vue
@@ -6,7 +6,8 @@
     <slot></slot>
     <div
       v-if="showEmpty"
-      class="col-span-1 px-6 text-sm py-4 grid grid-cols-1 md:grid-cols-5 text-gray-200 bg-gray-900 items-center rounded-sm"
+      class="col-span-1 px-6 text-sm py-4 text-gray-200 items-center rounded-sm"
+      :class="[light ? 'bg-gray-850 rounded' : 'bg-gray-900']"
     >
       <slot name="empty" />
     </div>
@@ -18,6 +19,11 @@ import Vue from 'vue'
 
 export default Vue.extend({
   props: {
+    light: {
+      type: Boolean,
+      default: false
+    },
+
     showEmpty: {
       type: Boolean,
       default: false

--- a/components/partials/common/markets/markets.vue
+++ b/components/partials/common/markets/markets.vue
@@ -58,9 +58,11 @@
     </v-panel>
 
     <div v-if="filterType !== MarketFilterType.All" class="text-center">
-      <v-button lg primary class="w-60 mt-6" @click="showAllMarkets">
-        {{ $t('home.viewAllMarkets') }}
-      </v-button>
+      <nuxt-link :to="{ name: 'markets' }">
+        <v-button lg primary class="w-60 mt-6">
+          {{ $t('home.viewAllMarkets') }}
+        </v-button>
+      </nuxt-link>
     </div>
   </div>
 </template>
@@ -188,10 +190,6 @@ export default Vue.extend({
         .finally(() => {
           this.status.setIdle()
         })
-    },
-
-    showAllMarkets() {
-      this.$root.$emit('toggle-market-slideout-from-content')
     },
 
     updateFilterType(type: MarketFilterType) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -60,7 +60,7 @@ export default Vue.extend({
     showFooter(): boolean {
       const { $route } = this
 
-      return ['index', 'portfolio'].includes($route.name as string)
+      return ['index', 'portfolio', 'markets'].includes($route.name as string)
     }
   },
 

--- a/locales/market/en.ts
+++ b/locales/market/en.ts
@@ -6,9 +6,8 @@ export default {
     topVolume: 'Top Volume',
     category: 'Category',
     market: 'Market',
-    lastPrice: 'Last Price',
-    change: 'Change (24H)',
-    volume: 'Volume (24H)'
+    emptyHeader: 'No markets found',
+    emptyDescription: 'Try another search term or you can propose some!'
   },
 
   marketPage: {


### PR DESCRIPTION
## This PR
- resolves #688
- innovation list is configured based on the list provided [here](https://www.notion.so/injective/4e87d9197608449ca4d9b855d89f12bc?v=3f6a4eb3e56544f4997625b4606872df)

## Screenshots:
- ### Sort
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/10151054/163402449-bdecb73e-7087-47f1-b3ef-0ab4672b6eea.png">

- ### Search filter
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/10151054/163402637-87dd3f6e-d50b-4e31-80df-ca022b3d1fcb.png">

- ### Category filter
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/10151054/163402695-e73d8557-2ce8-4129-b820-dd14017b3dd9.png">

- ### Stablecoin filter
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/10151054/163402733-2b055709-c5bd-4af9-82ea-119177172c77.png">

- ### Type filter
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/10151054/163402795-b987bae2-9d90-4911-be13-e145120d7251.png">

- ### Empty list
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/10151054/163402930-7e2c7125-3cc7-45d9-b709-5146ec19608d.png">