### PR TITLE
feat: market page mobile stats

### DIFF
--- a/assets/css/components/_animate.scss
+++ b/assets/css/components/_animate.scss
@@ -6,7 +6,7 @@
 .fade-left-leave-active,
 .fade-right-enter-active,
 .fade-right-leave-active {
-  transition: 300ms cubic-bezier(0.59, 0.12, 0.34, 0.95);
+  transition: 400ms cubic-bezier(0.59, 0.12, 0.34, 0.95);
   transition-property: opacity, transform;
 }
 

--- a/components/elements/info-icon-tooltip.vue
+++ b/components/elements/info-icon-tooltip.vue
@@ -32,7 +32,7 @@ export default Vue.extend({
 
   computed: {
     classes(): string[] {
-      return this.lg ? ['w-4', 'w-4'] : ['w-3', 'w-3']
+      return this.lg ? ['min-w-4', 'w-4', 'w-4'] : ['min-w-3', 'w-3', 'w-3']
     }
   }
 })

--- a/components/elements/market-info.vue
+++ b/components/elements/market-info.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="px-4 w-auto md:px-2 lg:px-3 2xl:px-4">
+  <div class="w-auto lg:px-3 2xl:px-4">
     <span
-      class="text-gray-500 mb-1 w-full text-right text-xs flex items-center justify-between whitespace-nowrap"
+      class="text-gray-500 mb-1 w-full lg:text-right text-xs flex items-center lg:justify-between whitespace-nowrap"
     >
       {{ title }}
       <v-icon-info-tooltip v-if="tooltip" class="ml-2" :tooltip="tooltip" />

--- a/components/partials/common/market/index.vue
+++ b/components/partials/common/market/index.vue
@@ -1,33 +1,53 @@
 <template>
   <div class="bg-gray-800 shadow-sm px-4 py-1 rounded-xl">
     <div
-      class="flex flex-wrap items-center mt-1 py-2 lg:py-1 cursor-pointer"
-      @click="handleTokenClick"
+      class="mt-1 py-2 lg:py-1 cursor-pointer grid grid-cols-1 lg:grid-cols-3 2xl:grid-cols-4"
     >
-      <div class="flex items-center pr-4 w-auto justify-start border-r">
-        <img
-          :src="market.baseToken.logo"
-          :alt="market.baseToken.name"
-          class="w-6 h-6 mr-4"
-        />
-        <div class="leading-none">
-          <p class="text-gray-100 font-semibold text-sm flex items-center">
-            <span>{{ market.ticker }}</span>
-            <v-icon-chevron
-              class="w-auto h-3 text-gray-500 ml-1.5 transform transition ease-in-out duration-300 delay-100"
-              :class="[expanded ? '-rotate-90' : 'rotate-90']"
-            />
-          </p>
-          <p class="text-gray-500 text-xs">
-            {{ market.baseToken.name }}
-          </p>
+      <div class="flex items-center w-auto justify-between lg:pr-5">
+        <div class="flex items-center" @click="handleTokenClick">
+          <img
+            :src="market.baseToken.logo"
+            :alt="market.baseToken.name"
+            class="w-6 h-6 mr-4"
+          />
+          <div class="leading-none">
+            <p class="text-gray-100 font-semibold text-sm flex items-center">
+              <span>{{ market.ticker }}</span>
+              <v-icon-chevron
+                class="w-auto h-3 text-gray-500 ml-2 transform transition ease-in-out duration-300 delay-100"
+                :class="[expanded ? '-rotate-90' : 'rotate-90']"
+              />
+            </p>
+            <p class="text-gray-500 text-xs">
+              {{ market.baseToken.name }}
+            </p>
+          </div>
         </div>
+
+        <div class="w-px h-8 border-r hidden lg:block" />
+
+        <v-last-traded-price-and-change
+          :market="market"
+          :summary="summary"
+          lg
+        />
       </div>
+
       <v-market-stats
         :market="market"
         :summary="summary"
-        class="flex-1 mt-4 md:mt-0 overflow-x-auto"
+        class="hidden lg:block flex-1 overflow-x-auto col-span-2 2xl:col-span-3"
       />
+
+      <!-- mobile stats -->
+      <transition name="fade-up">
+        <v-market-stats
+          v-if="expanded"
+          :market="market"
+          :summary="summary"
+          class="lg:hidden mt-4"
+        />
+      </transition>
     </div>
   </div>
 </template>
@@ -40,11 +60,13 @@ import {
   UiSpotMarketSummary,
   UiSpotMarketWithToken
 } from '@injectivelabs/ui-common'
-import MarketStats from './stats.vue'
+import VMarketStats from './stats.vue'
+import VLastTradedPriceAndChange from './last-traded-price-and-change.vue'
 
 export default Vue.extend({
   components: {
-    'v-market-stats': MarketStats
+    VLastTradedPriceAndChange,
+    VMarketStats
   },
 
   props: {

--- a/components/partials/common/market/last-traded-price-and-change.vue
+++ b/components/partials/common/market/last-traded-price-and-change.vue
@@ -1,0 +1,196 @@
+<template>
+  <div>
+    <div class="flex flex-col items-end">
+      <div class="flex items-center tracking-wide" :class="{ 'text-xs': !lg }">
+        <v-icon-arrow
+          v-if="!lastTradedPrice.isNaN() && lastTradedPrice.gt(0)"
+          class="transform w-3 h-3 mr-1"
+          :class="{
+            'text-aqua-500 rotate-90': lastPriceChange !== Change.Decrease,
+            'text-red-500 -rotate-90': lastPriceChange === Change.Decrease
+          }"
+        />
+        <span
+          v-if="!lastTradedPrice.isNaN()"
+          :class="{
+            'text-aqua-500': lastPriceChange !== Change.Decrease,
+            'text-red-500': lastPriceChange === Change.Decrease
+          }"
+        >
+          {{ lastTradedPriceToFormat }}
+        </span>
+        <span v-else class="text-gray-400">&mdash;</span>
+      </div>
+
+      <div v-if="!change.isNaN()" class="mt-1 text-xs">
+        <span :class="change.gte(0) ? 'text-aqua-500' : 'text-red-500'">
+          {{ changeToFormat }}%
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import { BigNumberInBase } from '@injectivelabs/utils'
+import {
+  MarketType,
+  UiDerivativeMarketSummary,
+  UiDerivativeMarketWithToken,
+  UiSpotMarketSummary,
+  UiSpotMarketWithToken,
+  ZERO_IN_BASE
+} from '@injectivelabs/ui-common'
+import { UI_DEFAULT_PRICE_DISPLAY_DECIMALS } from '~/app/utils/constants'
+import { Change } from '~/types'
+
+const { metaTags } = require('~/meta.config')
+
+export default Vue.extend({
+  props: {
+    market: {
+      type: Object as PropType<
+        UiDerivativeMarketWithToken | UiSpotMarketWithToken
+      >,
+      required: true
+    },
+
+    lg: {
+      type: Boolean,
+      default: false
+    },
+
+    summary: {
+      type: Object as PropType<UiDerivativeMarketSummary | UiSpotMarketSummary>,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      Change
+    }
+  },
+
+  computed: {
+    currentSpotMarket(): UiSpotMarketWithToken | undefined {
+      return this.$accessor.spot.market
+    },
+
+    currentDerivativeMarket(): UiDerivativeMarketWithToken | undefined {
+      return this.$accessor.derivatives.market
+    },
+
+    currentLastSpotTradedPrice(): BigNumberInBase {
+      return this.$accessor.spot.lastTradedPrice
+    },
+
+    currentLastDerivativeTradedPrice(): BigNumberInBase {
+      return this.$accessor.derivatives.lastTradedPrice
+    },
+
+    /* Current market is the market that we are currently trading on */
+    currentMarket():
+      | UiSpotMarketWithToken
+      | UiDerivativeMarketWithToken
+      | undefined {
+      const { currentSpotMarket, currentDerivativeMarket, market } = this
+
+      return market.type === MarketType.Spot
+        ? currentSpotMarket
+        : currentDerivativeMarket
+    },
+
+    currentLastTradedPrice(): BigNumberInBase {
+      const {
+        currentLastSpotTradedPrice,
+        currentLastDerivativeTradedPrice,
+        market
+      } = this
+
+      return market.type === MarketType.Spot
+        ? currentLastSpotTradedPrice
+        : currentLastDerivativeTradedPrice
+    },
+
+    lastTradedPrice(): BigNumberInBase {
+      const { market, currentMarket, currentLastTradedPrice, summary } = this
+
+      if (!market || !summary || !summary.price) {
+        return ZERO_IN_BASE
+      }
+
+      if (
+        currentMarket &&
+        currentMarket.marketId === market.marketId &&
+        currentLastTradedPrice
+      ) {
+        return currentLastTradedPrice
+      }
+
+      return new BigNumberInBase(summary.lastPrice || summary.price)
+    },
+
+    lastTradedPriceToFormat(): string {
+      const { lastTradedPrice } = this
+
+      return lastTradedPrice.toFormat(UI_DEFAULT_PRICE_DISPLAY_DECIMALS)
+    },
+
+    quoteVolume(): BigNumberInBase {
+      const { summary } = this
+
+      if (!summary || !summary.volume) {
+        return ZERO_IN_BASE
+      }
+
+      return new BigNumberInBase(summary.volume)
+    },
+
+    change(): BigNumberInBase {
+      const { summary } = this
+
+      if (!summary || !summary.change) {
+        return ZERO_IN_BASE
+      }
+
+      return new BigNumberInBase(summary.change)
+    },
+
+    changeToFormat(): string {
+      const { change } = this
+
+      return change.toFormat(2)
+    },
+
+    lastPriceChange(): Change {
+      const { summary } = this
+
+      if (!summary) {
+        return Change.NoChange
+      }
+
+      if (!summary.lastPriceChange) {
+        return Change.NoChange
+      }
+
+      return summary.lastPriceChange
+    }
+  },
+
+  watch: {
+    lastTradedPriceToFormat(newPrice: string) {
+      const { market } = this
+
+      if (market) {
+        document.title = `${newPrice} - ${market.ticker} | ${metaTags.title}`
+      }
+    }
+  },
+
+  beforeDestroy() {
+    document.title = metaTags.title
+  }
+})
+</script>

--- a/components/partials/common/market/next-funding.vue
+++ b/components/partials/common/market/next-funding.vue
@@ -4,7 +4,7 @@
     :title="$t('trade.next_funding')"
     :tooltip="$t('trade.next_funding_tooltip')"
   >
-    <span class="text-sm text-right font-mono block">
+    <span class="text-xs lg:text-right font-mono block">
       <v-countdown v-if="msUntilFunding > 0" :time="msUntilFunding">
         <template slot-scope="{ hours, minutes, seconds }">
           {{ hours >= 10 ? hours : '0' + hours }}:{{

--- a/components/partials/common/market/stats.vue
+++ b/components/partials/common/market/stats.vue
@@ -1,34 +1,14 @@
 <template>
   <div v-if="market">
-    <div class="flex overflow-x-auto overflow-y-none">
-      <v-market-info
-        :title="$t('trade.last_traded_price')"
-        :tooltip="$t('trade.last_traded_price_tooltip')"
-      >
-        <span
-          v-if="!currentLastTrade.isNaN()"
-          class="text-sm text-right font-mono block"
-        >
-          <span
-            :class="{
-              'text-aqua-500': currentLastTradeChange === Change.Increase,
-              'text-red-500': currentLastTradeChange === Change.Decrease
-            }"
-          >
-            {{ currentLastTradePriceToFormat }}
-          </span>
-        </span>
-        <span v-else class="text-gray-400">&mdash;</span>
-      </v-market-info>
+    <div
+      class="grid grid-cols-2 md:grid-cols-3 gap-2.5 lg:gap-0 lg:flex overflow-x-auto overflow-y-none text-xs"
+    >
       <v-market-info
         v-if="market.type === MarketType.Derivative"
         :title="$t('trade.mark_price')"
         :tooltip="$t('trade.mark_price_tooltip')"
       >
-        <span
-          v-if="!markPrice.isNaN()"
-          class="text-sm text-right font-mono block"
-        >
+        <span v-if="!markPrice.isNaN()" class="lg:text-right font-mono block">
           <span
             :class="{
               'text-aqua-500': currentLastTradeChange === Change.Increase,
@@ -41,41 +21,25 @@
         <span v-else class="text-gray-400">&mdash;</span>
       </v-market-info>
       <v-market-info
-        :title="$t('trade.market_change_24h')"
-        :tooltip="$t('trade.market_change_24h_tooltip')"
-      >
-        <span v-if="!change.isNaN()" class="text-sm text-right font-mono block">
-          <span
-            :class="{
-              'text-aqua-500': change.gte(0),
-              'text-red-500': change.lt(0)
-            }"
-          >
-            {{ (change.gt(0) ? '+' : '') + change.toFormat(2) }}%
-          </span>
-        </span>
-        <span v-else class="text-gray-400">&mdash;</span>
-      </v-market-info>
-      <v-market-info
         :title="$t('trade.volume_asset', { asset: market.quoteToken.symbol })"
         :tooltip="$t('trade.market_volume_24h_tooltip')"
       >
         <span
           v-if="volume.gt(0) && !volume.isNaN()"
-          class="text-sm text-right font-mono block"
+          class="lg:text-right font-mono block"
         >
           {{ volumeToFormat }}
         </span>
         <span v-else class="text-gray-400">&mdash;</span>
       </v-market-info>
       <v-market-info :title="$t('trade.high')">
-        <span class="text-sm text-right font-mono block">
+        <span class="lg:text-right font-mono block">
           <span v-if="high.gt(0) && !high.isNaN()">{{ highToFormat }}</span>
           <span v-else class="text-gray-400">&mdash;</span>
         </span>
       </v-market-info>
       <v-market-info :title="$t('trade.low')">
-        <span class="text-sm text-right font-mono block">
+        <span class="lg:text-right font-mono block">
           <span v-if="low.gt(0) && !low.isNaN()">{{ lowToFormat }}</span>
           <span v-else class="text-gray-400">&mdash;</span>
         </span>
@@ -85,10 +49,7 @@
         :title="$t('trade.est_funding_rate')"
         :tooltip="$t('trade.funding_rate_tooltip')"
       >
-        <span
-          v-if="!fundingRate.isNaN()"
-          class="text-sm text-right font-mono block"
-        >
+        <span v-if="!fundingRate.isNaN()" class="lg:text-right font-mono block">
           <span
             :class="{
               'text-aqua-500': fundingRate.gte(0),
@@ -101,14 +62,14 @@
             }}%
           </span>
         </span>
-        <span v-else class="text-sm text-right font-mono block">&mdash;</span>
+        <span v-else class="lg:text-right font-mono block">&mdash;</span>
       </v-market-info>
       <v-market-next-funding v-if="market.type === MarketType.Derivative" />
       <v-market-info
         v-if="market.type === MarketType.Derivative && expiryAt"
         :title="$t('trade.expiry_date')"
       >
-        <span class="text-sm text-right font-mono block">
+        <span class="lg:text-right font-mono block">
           {{ expiryAt }}
         </span>
       </v-market-info>
@@ -134,8 +95,6 @@ import { SpotOrderSide } from '@injectivelabs/spot-consumer'
 import MarketNextFunding from './next-funding.vue'
 import { UI_DEFAULT_PRICE_DISPLAY_DECIMALS } from '~/app/utils/constants'
 import MarketInfo from '~/components/elements/market-info.vue'
-
-const { metaTags } = require('~/meta.config')
 
 export default Vue.extend({
   components: {
@@ -167,14 +126,6 @@ export default Vue.extend({
   },
 
   computed: {
-    currentSpotMarket(): UiSpotMarketWithToken | undefined {
-      return this.$accessor.spot.market
-    },
-
-    currentDerivativeMarket(): UiDerivativeMarketWithToken | undefined {
-      return this.$accessor.derivatives.market
-    },
-
     currentLastSpotTradedPrice(): BigNumberInBase {
       return this.$accessor.spot.lastTradedPrice
     },
@@ -193,29 +144,6 @@ export default Vue.extend({
 
     derivativeMarkPrice(): string {
       return this.$accessor.derivatives.marketMarkPrice
-    },
-
-    currentMarket():
-      | UiSpotMarketWithToken
-      | UiDerivativeMarketWithToken
-      | undefined {
-      const { currentSpotMarket, currentDerivativeMarket, market } = this
-
-      return market.type === MarketType.Spot
-        ? currentSpotMarket
-        : currentDerivativeMarket
-    },
-
-    currentLastTrade(): BigNumberInBase {
-      const {
-        currentLastSpotTradedPrice,
-        currentLastDerivativeTradedPrice,
-        market
-      } = this
-
-      return market.type === MarketType.Spot
-        ? currentLastSpotTradedPrice
-        : currentLastDerivativeTradedPrice
     },
 
     markPrice(): BigNumberInBase {
@@ -240,16 +168,6 @@ export default Vue.extend({
       }
 
       return markPrice.toFormat(market.priceDecimals)
-    },
-
-    currentLastTradePriceToFormat(): string {
-      const { market, currentLastTrade } = this
-
-      if (!market) {
-        return currentLastTrade.toFormat(UI_DEFAULT_PRICE_DISPLAY_DECIMALS)
-      }
-
-      return currentLastTrade.toFormat(market.priceDecimals)
     },
 
     currentLastTradeChange(): Change {
@@ -357,16 +275,6 @@ export default Vue.extend({
       return new BigNumberInBase(estFundingRate).multipliedBy(100)
     },
 
-    change(): BigNumberInBase {
-      const { market, summary } = this
-
-      if (!market || !summary) {
-        return ZERO_IN_BASE
-      }
-
-      return new BigNumberInBase(summary.change)
-    },
-
     low(): BigNumberInBase {
       const { market, summary } = this
 
@@ -431,31 +339,7 @@ export default Vue.extend({
           addSuffix: true
         }
       )
-    },
-
-    lastTradedPriceToString(): string {
-      const { currentLastTrade } = this
-
-      if (currentLastTrade.isNaN() || currentLastTrade.lte(0)) {
-        return '0.00'
-      }
-
-      return `${currentLastTrade.toFormat(UI_DEFAULT_PRICE_DISPLAY_DECIMALS)}`
     }
-  },
-
-  watch: {
-    lastTradedPriceToString(newPrice: string) {
-      const { market } = this
-
-      if (market) {
-        document.title = `${newPrice} - ${market.ticker} | ${metaTags.title}`
-      }
-    }
-  },
-
-  beforeDestroy() {
-    document.title = metaTags.title
   }
 })
 </script>

--- a/layouts/market.vue
+++ b/layouts/market.vue
@@ -12,7 +12,12 @@
       </div>
       <div class="flex-1 grid grid-cols-6 lg:grid-cols-12 gap-1 p-1">
         <div class="col-span-6 lg:col-span-3 4xl:col-span-3 overflow-y-hidden">
-          <transition-group name="fade-up" mode="out-in">
+          <transition-group
+            enter-active-class="duration-700"
+            leave-active-class="duration-300"
+            name="fade-up"
+            mode="out-in"
+          >
             <v-market-selection
               v-show="showMarketList"
               key="market-selection"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -209,6 +209,7 @@ module.exports = {
       },
 
       minWidth: {
+        3: '0.75rem',
         4: '1rem',
         6: '1.5rem',
         ...extraSizings


### PR DESCRIPTION
## This PR:
- implements market page mobile stats
- figma [design](https://www.figma.com/file/qJtXzfX9nzh0c7yA6G9iI3/Injective-DEX?node-id=3940%3A7427)

## Screenshot:
- ### 375px
<img width="353" alt="image" src="https://user-images.githubusercontent.com/10151054/163972189-fbdee633-ad8f-4b6a-9e96-32dd073aacc9.png">

- ### 480px
<img width="435" alt="image" src="https://user-images.githubusercontent.com/10151054/163972241-4749a6e3-58c4-433c-9dbb-433a72aff8d4.png">

- ### 640px
<img width="577" alt="image" src="https://user-images.githubusercontent.com/10151054/163972279-39971eb6-b3a0-4a24-8ea9-6732f8e453eb.png">

- ### 768px
<img width="578" alt="image" src="https://user-images.githubusercontent.com/10151054/163972327-1e918c82-bfbb-4a2b-84f7-16f88deda4ce.png">

- ### 1024px
<img width="772" alt="image" src="https://user-images.githubusercontent.com/10151054/163972541-27ebb280-5b42-4f54-9bd6-fdbd6cf87cf8.png">

- ### 1366px
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/10151054/163972587-c6ec012f-4860-473a-bcc8-4b3742172b13.png">
