### PR TITLE
Show mark_price next to the last_traded_price in derivatives orderbook (#778)

### DIFF
--- a/components/partials/derivatives/orderbook/order-book.vue
+++ b/components/partials/derivatives/orderbook/order-book.vue
@@ -32,17 +32,6 @@
       class="orderbook-middle-h bg-gray-900 flex flex-col items-center justify-center border-t border-b"
     >
       <div class="w-full flex items-center justify-center">
-        <v-icon-arrow
-          v-if="
-            [Change.Increase, Change.Decrease].includes(lastTradedPriceChange)
-          "
-          class="transform w-3 h-3 lg:w-4 lg:h-4 4xl:w-5 4xl:h-5"
-          :class="{
-            'text-red-500 -rotate-90':
-              lastTradedPriceChange === Change.Decrease,
-            'text-aqua-500 rotate-90': lastTradedPriceChange === Change.Increase
-          }"
-        />
         <span
           :class="{
             'text-red-500': lastTradedPriceChange === Change.Decrease,
@@ -51,6 +40,23 @@
           class="font-bold font-mono text-base lg:text-lg 4xl:text-xl"
         >
           {{ lastTradedPriceToFormat }}
+        </span>
+        <v-icon-arrow
+          v-if="
+            [Change.Increase, Change.Decrease].includes(lastTradedPriceChange)
+          "
+          class="transform w-3 h-3 lg:w-4 lg:h-4 4xl:w-5 4xl:h-5 ml-2 mr-4"
+          :class="{
+            'text-red-500 -rotate-90':
+              lastTradedPriceChange === Change.Decrease,
+            'text-aqua-500 rotate-90': lastTradedPriceChange === Change.Increase
+          }"
+        />
+        <span
+          v-tooltip="{ content: $t('trade.mark_price_tooltip_verbose') }"
+          class="text-gray-500 underline font-mono text-base lg:text-sm 4xl:text-md cursor-pointer"
+        >
+          {{ markPriceToFormat }}
         </span>
       </div>
     </div>
@@ -185,6 +191,30 @@ export default Vue.extend({
       }
 
       return lastTradedPrice.toFormat(market.priceDecimals)
+    },
+
+    derivativeMarkPrice(): string {
+      return this.$accessor.derivatives.marketMarkPrice
+    },
+
+    markPrice(): BigNumberInBase {
+      const { derivativeMarkPrice } = this
+
+      if (!derivativeMarkPrice) {
+        return ZERO_IN_BASE
+      }
+
+      return new BigNumberInBase(derivativeMarkPrice)
+    },
+
+    markPriceToFormat(): string {
+      const { market, markPrice } = this
+
+      if (!market) {
+        return markPrice.toFormat(UI_DEFAULT_PRICE_DISPLAY_DECIMALS)
+      }
+
+      return markPrice.toFormat(market.priceDecimals)
     },
 
     buys(): UiPriceLevel[] {

--- a/locales/trade/en.ts
+++ b/locales/trade/en.ts
@@ -87,6 +87,7 @@ export default {
     sell_short: 'Sell/Short',
     mark_price: 'Mark Price',
     mark_price_tooltip: 'The oracle price for the base asset.',
+    mark_price_tooltip_verbose: 'Mark Price: The oracle price for the base asset.',
     funding_rate_tooltip:
       'The interest rate paid is determined by the difference between the perpetual swap price and the underlying spot price. If the funding rate is positive, traders with long positions will pay traders with short positions. If the funding rate is negative, traders with short positions will pay those in long positions.',
     est_receiving_amount: 'Est. Receiving Amount (Worst Case)',


### PR DESCRIPTION
### This PR
Closes #778 by adding the mark_price next to the last_traded_price inside the orderbook for derivatives.

### Design
![image](https://user-images.githubusercontent.com/10757768/167576526-90f4a38b-7637-4671-820e-fdcbb2ac748e.png)

