### PR TITLE
fix: trading view remove 7D and 30D resolutions from selection list

### DIFF
--- a/components/trading-view/datafeed/datafeed.ts
+++ b/components/trading-view/datafeed/datafeed.ts
@@ -10,9 +10,22 @@ export const extractField = (data: any, field: string, arrayIndex: number) => {
 
 export const defaultConfiguration = () => {
   return {
-    supports_search: false,
-    supports_group_request: true,
-    supported_resolutions: ['1', '5', '15', '30', '60', '1D', '1W', '1M'],
+    exchanges: [],
+    supports_search: true,
+    supports_group_request: false,
+    supported_resolutions: [
+      '1',
+      '3',
+      '5',
+      '15',
+      '30',
+      '60',
+      '120',
+      '240',
+      '360',
+      '1D',
+      '1W'
+    ],
     supports_marks: false,
     supports_timescale_marks: false
   }
@@ -42,11 +55,9 @@ export class Datafeed {
       updateFrequency
     )
 
-    this.configurationReadyPromise = this.requestConfiguration().then(
-      (configuration: any) => {
-        this.setupWithConfiguration(configuration || defaultConfiguration())
-      }
-    )
+    this.configurationReadyPromise = this.requestConfiguration().then(() => {
+      this.setupWithConfiguration(defaultConfiguration())
+    })
   }
 
   onReady(callback: Function) {


### PR DESCRIPTION
## This PR:
- did a deep dive into the trading view implementation and it seems that the [getBars()](https://github.com/InjectiveLabs/injective-dex/blob/ef11d412fa8adccb446c8b5a764989e210e5b5de/components/trading-view/datafeed/datafeed.ts#L150) function cannot differentiate between `1D`, `7D` or `30D`.
- The resolution is always returned as `D`, hence the [periodLengthSeconds](https://github.com/InjectiveLabs/injective-dex/blob/ef11d412fa8adccb446c8b5a764989e210e5b5de/components/trading-view/datafeed/data-pulse-provider.ts#L109) function are not returning the correct calculation. 
- on a separate note, BE is treating `D` as `1D` by default, confirmed by @vinhphuctadang.
- Seems like the [charting_library repo](https://github.com/tradingview/charting_library/wiki/UDF) is deprecated, in the meantime, **I've removed the `7D` and `30D` options from our trading view dropdown option as a temporary fix** until we implement a more permanent fix.

## Screenshot:
<img width="168" alt="image" src="https://user-images.githubusercontent.com/10151054/168772363-0bf091cc-2a54-426c-94fe-2185381b7fbe.png">

