### PR TITLE
chore: weth usdt remove price outliers

### DIFF
--- a/app/data/trading-view.ts
+++ b/app/data/trading-view.ts
@@ -66,6 +66,19 @@ const hardcodedExcludedTradesByMarket = {
     excludeBefore: null,
     bars: [
       {
+        high: 4349.99,
+        barMap: (bar: any) => ({ ...bar, close: 2114.333, high: 2114.333 })
+      },
+      {
+        high: 4349.999,
+        barMap: (bar: any) => ({
+          ...bar,
+          high: 2080.106,
+          low: 2080.106,
+          close: 2080.106
+        })
+      },
+      {
         low: 1320.958,
         barMap: (bar: any) => ({ ...bar, low: 2710 })
       }


### PR DESCRIPTION
## This PR:
- removes wEth/usdt 4399.99 and 4399.999 price outliers

## Screenshots:
| Before | After |
|-------|-------|
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/10151054/168781807-09090dc4-6759-4e78-9f78-b8a6c89452b2.png"> | <img width="754" alt="image" src="https://user-images.githubusercontent.com/10151054/168781701-38320ce0-0bd6-4ca5-a912-816a00a212be.png"> |