### PR TITLE
chore: hide expected pts. field from trade details

### DIFF
--- a/components/partials/derivatives/trading/order-details-market.vue
+++ b/components/partials/derivatives/trading/order-details-market.vue
@@ -137,7 +137,7 @@
           <span v-else class="text-gray-500 ml-1"> &mdash; </span>
         </TextInfo>
 
-        <TextInfo
+        <!-- <TextInfo
           v-if="takerExpectedPts.gte(0)"
           :title="$t('trade.expected_points')"
           class="mt-2"
@@ -153,7 +153,7 @@
               {{ $t('pts') }}
             </span>
           </span>
-        </TextInfo>
+        </TextInfo> -->
 
         <p class="mt-4 text-gray-500 text-xs">
           {{ $t('trade.worst_price_note', { slippage: slippage.toFixed() }) }}

--- a/components/partials/derivatives/trading/order-details.vue
+++ b/components/partials/derivatives/trading/order-details.vue
@@ -174,7 +174,7 @@
           <span v-else class="text-gray-500 ml-1"> &mdash; </span>
         </TextInfo>
 
-        <TextInfo
+        <!-- <TextInfo
           v-if="makerExpectedPts.gte(0) || takerExpectedPts.gte(0)"
           :title="$t('trade.expected_points')"
           class="mt-2"
@@ -190,7 +190,7 @@
               {{ $t('pts') }}
             </span>
           </span>
-        </TextInfo>
+        </TextInfo> -->
       </div>
     </VDrawer>
   </div>

--- a/components/partials/spot/trading/order-details-market.vue
+++ b/components/partials/spot/trading/order-details-market.vue
@@ -113,7 +113,7 @@
           <span v-else class="text-gray-500 ml-1"> &mdash; </span>
         </TextInfo>
 
-        <TextInfo
+        <!-- <TextInfo
           v-if="takerExpectedPts.gte(0)"
           :title="$t('trade.expected_points')"
           class="mt-2"
@@ -129,7 +129,7 @@
               {{ $t('pts') }}
             </span>
           </span>
-        </TextInfo>
+        </TextInfo> -->
 
         <p class="mt-4 text-gray-500 text-xs">
           {{ $t('trade.worst_price_note', { slippage: slippage.toFixed() }) }}

--- a/components/partials/spot/trading/order-details.vue
+++ b/components/partials/spot/trading/order-details.vue
@@ -145,7 +145,7 @@
           <span v-else class="text-gray-500 ml-1"> &mdash; </span>
         </TextInfo>
 
-        <TextInfo
+        <!-- <TextInfo
           v-if="makerExpectedPts.gte(0) || takerExpectedPts.gte(0)"
           :title="$t('trade.expected_points')"
           class="mt-2"
@@ -161,7 +161,7 @@
               {{ $t('pts') }}
             </span>
           </span>
-        </TextInfo>
+        </TextInfo> -->
       </div>
     </VDrawer>
   </div>


### PR DESCRIPTION
This PR temporarily hides the expected pts. field from the trade details as was requested in #880.