### PR TITLE
Preserve negative sign for trade history fees #368

### DIFF
--- a/components/partials/common/elements/number.vue
+++ b/components/partials/common/elements/number.vue
@@ -93,6 +93,7 @@ export default Vue.extend({
         return [formattedNumber]
       }
 
+      // Please note that this will remove the sign from any number passed to this function so negative becomes positive.
       const match = formattedNumber.match(/^-?([\d,]+)((\.)(\d+?\d+?)(0*))?$/)
       const groups = !match
         ? formattedNumber

--- a/components/partials/common/elements/number.vue
+++ b/components/partials/common/elements/number.vue
@@ -93,8 +93,7 @@ export default Vue.extend({
         return [formattedNumber]
       }
 
-      // Please note that this will remove the sign from any number passed to this function so negative becomes positive.
-      const match = formattedNumber.match(/^-?([\d,]+)((\.)(\d+?\d+?)(0*))?$/)
+      const match = formattedNumber.match(/^(-?[\d,]+)((\.)(\d+?\d+?)(0*))?$/)
       const groups = !match
         ? formattedNumber
           ? [formattedNumber]

--- a/components/partials/common/trade/trade.vue
+++ b/components/partials/common/trade/trade.vue
@@ -69,7 +69,6 @@
     <td class="h-8 text-right font-mono">
       <VNumber
         use-number-decimals
-        dont-group-values
         :number="fee"
         data-cy="trade-history-fee-table-data"
       >

--- a/components/partials/common/trade/trade.vue
+++ b/components/partials/common/trade/trade.vue
@@ -69,6 +69,7 @@
     <td class="h-8 text-right font-mono">
       <VNumber
         use-number-decimals
+        dont-group-values
         :number="fee"
         data-cy="trade-history-fee-table-data"
       >


### PR DESCRIPTION
This PR closes part of #368.

The modified regex will now also support negative numbers.