### PR TITLE
fix: ethereum withdrawal transaction max amount

### DIFF
--- a/store/token.ts
+++ b/store/token.ts
@@ -329,10 +329,14 @@ export const actions = actionTree(
 
       await this.app.$accessor.wallet.validate()
 
-      const actualAmount = amount.toWei(token.decimals).toFixed(0)
+      const amountToFixed = amount.toWei(token.decimals).toFixed(0)
       const actualBridgeFee = new BigNumberInWei(
         bridgeFee.toWei(token.decimals).toFixed(0)
       ).toFixed()
+
+      const actualAmount = new BigNumberInBase(amountToFixed)
+        .minus(actualBridgeFee)
+        .toFixed(0)
 
       const message = MsgSendToEth.fromJSON({
         address,


### PR DESCRIPTION
This PR:
resolves UI not subtracting bridgeFee from bridgeAmount resulting in error:
```rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: 
48490000000000000000peggy0x4d224452801ACEd8B2F0aebE155379bb5D594381 is smaller than 
50604164904862579281peggy0x4d224452801ACEd8B2F0aebE155379bb5D594381: insufficient funds: invalid request
```