### PR TITLE
chore: refactor cards on market page to use HorizontalScrollView

### DIFF
--- a/app/utils/animation.ts
+++ b/app/utils/animation.ts
@@ -1,0 +1,41 @@
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+export function square(t: number): number {
+  return Math.pow(t, 2)
+}
+
+export function flip (t: number): number {
+  return 1 - t
+}
+
+function easeIn(t: number): number {
+  return t * t
+}
+
+function easeOut(t: number) {
+  return flip(square(flip(t)))
+}
+
+function easeInOut(t: number): number {
+  return lerp(easeIn(t), easeOut(t), t)
+}
+
+function easeOutElastic(t: number): number {
+  const c4 = (2 * Math.PI) / 3
+
+  return t === 0
+    ? 0
+    : t === 1
+    ? 1
+    : Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1
+}
+
+export const Easings = {
+  easeIn,
+  easeOut,
+  easeInOut,
+  easeOutElastic
+}

--- a/components/elements/horizontal-scroll-view-indicator.vue
+++ b/components/elements/horizontal-scroll-view-indicator.vue
@@ -1,0 +1,18 @@
+<template>
+  <div
+    class="w-2 h-2 rounded-full bg-white"
+    :class="{ 'bg-opacity-50': active, 'bg-opacity-10': !active }"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({
+  props: {
+    active: {
+      type: Boolean,
+      default: false
+    }
+  }
+})
+</script>

--- a/components/elements/horizontal-scroll-view-indicator.vue
+++ b/components/elements/horizontal-scroll-view-indicator.vue
@@ -2,6 +2,7 @@
   <div
     class="w-2 h-2 rounded-full bg-white"
     :class="{ 'bg-opacity-50': active, 'bg-opacity-10': !active }"
+    @click="$emit('click')"
   />
 </template>
 

--- a/components/elements/horizontal-scroll-view.vue
+++ b/components/elements/horizontal-scroll-view.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <div
+      ref="views"
+      class="flex md:grid grid-cols-12 gap-6 overflow-x-auto hide-scrollbar"
+      @scroll="handleScroll"
+    >
+      <slot></slot>
+    </div>
+    <div class="flex gap-2 justify-center mt-4 md:hidden">
+      <HorizontalScrollViewIndicator
+        v-for="index in viewCount"
+        :key="`horizontal-scroll-view-indicator-${index}`"
+        :active="viewIndex === index - 1"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import HorizontalScrollViewIndicator from './horizontal-scroll-view-indicator.vue'
+
+export default Vue.extend({
+  components: {
+    HorizontalScrollViewIndicator
+  },
+
+  data() {
+    return {
+      viewCount: 0,
+      viewIndex: 0
+    }
+  },
+
+  mounted() {
+    window.addEventListener('resize', this.updateChildCount)
+    this.updateChildCount()
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('resize', this.updateChildCount)
+  },
+
+  methods: {
+    handleScroll(e: Event): void {
+      const target = e.target as HTMLElement
+      const offset = target.scrollLeft
+      const viewWidth = target.clientWidth
+      const total = target.scrollWidth - viewWidth
+
+      this.viewIndex = Math.round((offset / total) * 2)
+    },
+
+    updateChildCount(): void {
+      const viewsElement = this.$refs.views as HTMLElement
+
+      if (viewsElement) {
+        this.viewCount = viewsElement.children.length
+      }
+    }
+  }
+})
+</script>

--- a/components/partials/markets/overview.vue
+++ b/components/partials/markets/overview.vue
@@ -8,51 +8,10 @@
         {{ $t('markets.title') }}
       </h3>
 
-      <div
-        v-if="markets.length > 0"
-        v-touch:swipe.left="handleSwipeRight"
-        v-touch:swipe.right="handleSwipeLeft"
-        class="md:hidden"
-      >
-        <transition mode="out-in" :name="animation">
-          <MarketCard
-            v-if="newMarket && activeIndex === 1"
-            key="market-card-1"
-            :market="newMarket.market"
-            :summary="newMarket.summary"
-            :volume-in-usd="newMarket.volumeInUsd"
-          >
-            {{ $t('markets.whatsNew') }}
-          </MarketCard>
-
-          <MarketCard
-            v-if="topVolume && activeIndex === 2"
-            key="market-card-2"
-            :market="topVolume.market"
-            :summary="topVolume.summary"
-            :volume-in-usd="topVolume.volumeInUsd"
-          >
-            {{ $t('markets.topVolume') }}
-          </MarketCard>
-
-          <MarketCard
-            v-if="topGainer && activeIndex === 3"
-            key="market-card-3"
-            :market="topGainer.market"
-            :summary="topGainer.summary"
-            :volume-in-usd="topGainer.volumeInUsd"
-          >
-            {{ $t('markets.topGainer') }}
-          </MarketCard>
-        </transition>
-      </div>
-
-      <div
-        v-if="markets.length > 0"
-        class="hidden md:grid grid-cols-2 xl:grid-cols-3 gap-6 mt-6"
-      >
+      <HorizontalScrollView class="mt-6">
         <MarketCard
           v-if="newMarket"
+          class="flex-0-full col-span-6 xl:col-span-4"
           data-cy="market-card-whats-new"
           :market="newMarket.market"
           :summary="newMarket.summary"
@@ -63,6 +22,7 @@
 
         <MarketCard
           v-if="topVolume"
+          class="flex-0-full col-span-6 xl:col-span-4"
           data-cy="market-card-top-volume"
           :market="topVolume.market"
           :summary="topVolume.summary"
@@ -73,6 +33,7 @@
 
         <MarketCard
           v-if="topGainer"
+          class="flex-0-full col-span-6 xl:col-span-4"
           data-cy="market-card-top-gainer"
           :market="topGainer.market"
           :summary="topGainer.summary"
@@ -80,17 +41,7 @@
         >
           {{ $t('markets.topGainer') }}
         </MarketCard>
-      </div>
-
-      <div class="flex justify-center gap-2 mt-6 md:hidden">
-        <MarketDot
-          v-for="dot in dotCount"
-          :key="`market-dot-${dot}`"
-          :index="dot"
-          :active="activeIndex === dot"
-          @click="handleDotClick"
-        />
-      </div>
+      </HorizontalScrollView>
     </div>
   </div>
 </template>
@@ -99,7 +50,7 @@
 import Vue, { PropType } from 'vue'
 import { BigNumberInBase } from '@injectivelabs/utils'
 import MarketCard from '~/components/partials/markets/market-card.vue'
-import MarketDot from '~/components/partials/markets/market-dot.vue'
+import HorizontalScrollView from '~/components/elements/horizontal-scroll-view.vue'
 import { newMarketsSlug } from '~/app/data/market'
 import { UiMarketAndSummaryWithVolumeInUsd } from '~/types'
 
@@ -114,22 +65,14 @@ const sortMarketsAlphabetically = (
 
 export default Vue.extend({
   components: {
-    MarketCard,
-    MarketDot
+    HorizontalScrollView,
+    MarketCard
   },
 
   props: {
     markets: {
       type: Array as PropType<UiMarketAndSummaryWithVolumeInUsd[]>,
       required: true
-    }
-  },
-
-  data() {
-    return {
-      activeIndex: 1,
-      dotCount: 3,
-      animation: 'fade-right'
     }
   },
 
@@ -206,39 +149,6 @@ export default Vue.extend({
             : market
         }
       )
-    }
-  },
-
-  mounted() {},
-
-  methods: {
-    handleDotClick(index: number) {
-      this.animation = index > this.activeIndex ? 'fade-left' : 'fade-right'
-      this.activeIndex = index
-    },
-
-    handleSwipeRight() {
-      const { activeIndex, dotCount } = this
-
-      if (activeIndex === dotCount) {
-        this.activeIndex = 1
-        this.animation = 'fade-left'
-      } else {
-        this.animation = 'fade-right'
-        this.activeIndex = this.activeIndex + 1
-      }
-    },
-
-    handleSwipeLeft() {
-      const { activeIndex, dotCount } = this
-
-      if (activeIndex === 1) {
-        this.animation = 'fade-right'
-        this.activeIndex = dotCount
-      } else {
-        this.animation = 'fade-left'
-        this.activeIndex = this.activeIndex - 1
-      }
     }
   }
 })

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -132,6 +132,7 @@ module.exports = {
     extend: {
       flex: {
         '0-auto': '0 0 auto',
+        '0-full': '0 0 100%',
         2: '2 2 0%',
         3: '3 3 0%',
         4: '4 4 0%',


### PR DESCRIPTION
For the new Fee Discounts page I've created a HorizontalScrollView component that supports horizontal scrolling, swiping and navigating via the little dot indicators. After discussing with @ThomasRalee and @terencetang9 we came to the conclusion that we can also use this for the Markets page cards.

After this PR has been merged I will update [PR: Fee Discounts page redesign](https://github.com/InjectiveLabs/injective-dex/pull/888) so it uses the same version of `HorizontalScrollView`.

![horizontal-scroll-view](https://user-images.githubusercontent.com/10757768/176452932-072ce94a-2416-494e-9b81-58aa0d09a2f2.gif)