### PR TITLE
fix: fixed bug in getAbbreviatedVolume helper

### DIFF
--- a/app/utils/market.ts
+++ b/app/utils/market.ts
@@ -98,7 +98,7 @@ export const getAbbreviatedVolume = (value: BigNumberInBase): string => {
 
   if (value.gt(thousand)) {
     return `${value
-      .dividedBy(million)
+      .dividedBy(thousand)
       .toFormat(2, BigNumberInBase.ROUND_DOWN)}K`
   }
 


### PR DESCRIPTION
This PR fixes #910, we were using the incorrect variable when comparing numbers `> 1000` and `< 1000000`