### PR TITLE
Fix for broken Bridge token logo after TokenSelector modifications

### DIFF
--- a/components/partials/portfolio/bridge/token-selector/select.vue
+++ b/components/partials/portfolio/bridge/token-selector/select.vue
@@ -86,7 +86,7 @@
                 <div class="flex justify-end items-center h-[32px] ml-4">
                   <img
                     v-if="logo"
-                    :src="getTokenLogoWithVendorPathPrefix(logo)"
+                    :src="getLogo(logo)"
                     :alt="name"
                     class="rounded-full w-6 h-6"
                   />
@@ -267,8 +267,7 @@ export default Vue.extend({
       search: '',
       forceClose: true,
       isSearching: false,
-      isDropdownOpen: false,
-      getTokenLogoWithVendorPathPrefix
+      isDropdownOpen: false
     }
   },
 
@@ -321,6 +320,14 @@ export default Vue.extend({
   },
 
   methods: {
+    getLogo(logoPath: string): string {
+      if (logoPath.startsWith('/bridgingNetworks')) {
+        return logoPath
+      }
+
+      return getTokenLogoWithVendorPathPrefix(logoPath)
+    },
+
     resetInputFields() {
       if (this.$inputForm) {
         this.$inputForm.reset()


### PR DESCRIPTION
This PR closes #911, for bridging network logos we should not use the `getTokenLogoWithVendorPrefix` helper since the images are located in the static folder of this repo.