### PR TITLE
fix: fee discounts page - round up stakedAmount to two decimal places

### DIFF
--- a/components/partials/fee-discounts/staked-amount.vue
+++ b/components/partials/fee-discounts/staked-amount.vue
@@ -23,6 +23,7 @@ import Vue from 'vue'
 import { BigNumberInBase } from '@injectivelabs/utils'
 import { ZERO_IN_BASE } from '@injectivelabs/sdk-ui-ts'
 import { cosmosSdkDecToBigNumber, FeeDiscountAccountInfo } from '@injectivelabs/sdk-ts'
+import { UI_DEFAULT_MIN_DISPLAY_DECIMALS } from '~/app/utils/constants'
 
 export default Vue.extend({
   computed: {
@@ -55,7 +56,7 @@ export default Vue.extend({
     stakedAmountToFormat(): string {
       const { stakedAmount } = this
 
-      return stakedAmount.toFormat(2)
+      return stakedAmount.toFormat(UI_DEFAULT_MIN_DISPLAY_DECIMALS)
     }
   }
 })

--- a/components/partials/fee-discounts/staked-amount.vue
+++ b/components/partials/fee-discounts/staked-amount.vue
@@ -6,7 +6,7 @@
           {{ $t('fee_discounts.my_staked_amount') }}
         </span>
         <span class="uppercase text-xs lg:text-base text-gray-500 font-bold tracking-widest whitespace-nowrap">
-          <b class="text-xl lg:text-2xl font-bold text-white tracking-normal font-mono">{{ stakedAmount }}</b> INJ
+          <b class="text-xl lg:text-2xl font-bold text-white tracking-normal font-mono">{{ stakedAmountToFormat }}</b> INJ
         </span>
       </div>
     </div>
@@ -50,6 +50,12 @@ export default Vue.extend({
       return new BigNumberInBase(
         cosmosSdkDecToBigNumber(feeDiscountAccountInfo.accountInfo.stakedAmount)
       )
+    },
+
+    stakedAmountToFormat(): string {
+      const { stakedAmount } = this
+
+      return stakedAmount.toFormat(2)
     }
   }
 })


### PR DESCRIPTION
This PR fixes #927 by using default rounding on the `stakedAmount` before rendering.