### PR TITLE
fix: prevent double negative sign for negative funding payments

### DIFF
--- a/components/partials/common/derivatives/funding-payment.vue
+++ b/components/partials/common/derivatives/funding-payment.vue
@@ -34,7 +34,6 @@
           'text-red-500': total.lt(0)
         }"
         :decimals="UI_DEFAULT_MAX_DISPLAY_DECIMALS"
-        :prefix="total.lt(0) ? '-' : ''"
         :number="total"
       >
         <span slot="addon" class="text-2xs text-gray-500">


### PR DESCRIPTION
This PR fixes #930. It removes special handling for negative numbers as it is no longer needed because `number.vue` already handles negative numbers properly after #897.