### PR TITLE
[codex] Fix local demo startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,11 @@ VITE_NAME=
 # The url of your dex
 VITE_BASE_URL=http://localhost:3000
 # The network used to get pre-defined API endpoints.
-VITE_NETWORK=devnet
+VITE_NETWORK=mainnet
 # injective-1 for mainnet, injective-888 for testnet
 VITE_CHAIN_ID=injective-1
-# 1 for mainnet, 42 for kovan, 5 for Goerli, 11155111 for Sepolia
-VITE_ETHEREUM_CHAIN_ID=5
+# 1 for mainnet, 11155111 for Sepolia
+VITE_ETHEREUM_CHAIN_ID=1
 
 ## Flags
 # Whether to disable maintenance mode

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ _Helix | The Premier Decentralized Spot and Derivatives Exchange_
 1. Clone the repository
 
 ```bash
-$ git clone git@github.com:InjectiveLabs/injective-dex.git
-$ cd injective-dex
-$ yarn
+$ git clone https://github.com/InjectiveLabs/injective-helix-demo.git
+$ cd injective-helix-demo
+$ pnpm install
 ```
 
 2. Duplicate the .env.example to .env and fill in the values
 3. Compile the app locally
 
 ```bash
-$ yarn dev
+$ pnpm dev
 ```
 
 ## 📖 Documentation
 
-The `injective-helix` is built using Nuxt and TailwindCSS and its powered by the [injective-ts monorepo](https://github.com/InjectiveLabs/injective-ts/).
+The `injective-helix-demo` is built using Nuxt and TailwindCSS and its powered by the [injective-ts monorepo](https://github.com/InjectiveLabs/injective-ts/).
 
-You can always boot the dex locally on your own laptop without having to set up a relayer. You can use the `public` network in your `VITE_NETWORK` `.env` configuration variable and run the `yarn run dev` command. You can find all of the available networks (i.e - predefined set of endpoints) [here](https://github.com/InjectiveLabs/injective-ts/blob/17b1aa5df39d5724baf6262b276980cf722a1cba/packages/networks/src/types.ts#L1). Using these endpoints (from the `public`) network gives the 40% of the trading fees to the community spend pool.
+You can boot the demo locally without setting up a relayer. The checked-in `.env.example` uses the mainnet public endpoints from `@injectivelabs/networks`; copy it to `.env` and run `pnpm dev`. You can find all of the available networks (i.e - predefined set of endpoints) [here](https://github.com/InjectiveLabs/injective-ts/blob/17b1aa5df39d5724baf6262b276980cf722a1cba/packages/networks/src/types.ts#L1).
 
 ### Deployment
 
@@ -48,10 +48,10 @@ We've migrated the `injective-helix` repo to Nuxt3 in January, 2023. To make the
 
 1. Pull the latest codebase from the `injective-dex` repo, `master` branch,
 2. Resolve merge conflicts on your fork,
-3. Install the dependencies `yarn install`
-4. Clean up left overs from the previous deployments `yarn clean-up && rm -rf dist`
+3. Install the dependencies `pnpm install`
+4. Clean up left overs from the previous deployments `pnpm clean-up && rm -rf dist`
 5. Update your `.env` file and add `VITE_` prefix to all of the `.env` variables,
-6. Run the dex `yarn dev`
+6. Run the dex `pnpm dev`
 
 ---
 

--- a/nuxt-config/hooks/index.ts
+++ b/nuxt-config/hooks/index.ts
@@ -38,6 +38,21 @@ const HELIX_OPTIMIZE_DEPS = [
   '@shared/transformer/oracle'
 ]
 
+function aliasBufferEntrypoint(config: any) {
+  config.resolve = config.resolve || {}
+
+  if (Array.isArray(config.resolve.alias)) {
+    config.resolve.alias.push({ find: /^buffer$/, replacement: 'buffer/' })
+
+    return
+  }
+
+  config.resolve.alias = {
+    ...(config.resolve.alias || {}),
+    buffer: 'buffer/'
+  }
+}
+
 export default {
   'pages:extend'(pages) {
     const spotPage = pages.find((page) => page.name === TradePage.Spot)
@@ -81,6 +96,8 @@ export default {
     ]
   },
   'vite:extendConfig'(config: any) {
+    aliasBufferEntrypoint(config)
+
     if (isProduction) {
       return
     }

--- a/nuxt-config/hooks/index.ts
+++ b/nuxt-config/hooks/index.ts
@@ -6,6 +6,21 @@ import {
 import type { NitroConfig } from 'nitropack'
 import type { NuxtHooks } from 'nuxt/schema'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
+const HELIX_OPTIMIZE_DEPS = [
+  'buffer',
+  'clsx',
+  'gsap',
+  'js-sha3',
+  'gsap/ScrollTrigger',
+  'gsap/ScrollToPlugin',
+  'lightweight-charts',
+  'html-to-image',
+  'embla-carousel-vue',
+  '@injectivelabs/wallet-ledger'
+]
+
 export default {
   'pages:extend'(pages) {
     const spotPage = pages.find((page) => page.name === TradePage.Spot)
@@ -47,5 +62,15 @@ export default {
       ...Object.keys(verifiedSpotMarketIdMap).map((s) => `/spot/${s}`),
       ...Object.keys(verifiedDerivateMarketIdMap).map((s) => `/futures/${s}`)
     ]
+  },
+  'vite:extendConfig'(config: any) {
+    if (isProduction) {
+      return
+    }
+
+    config.optimizeDeps = config.optimizeDeps || {}
+    config.optimizeDeps.include = config.optimizeDeps.include || []
+    config.optimizeDeps.include.push(...HELIX_OPTIMIZE_DEPS)
+    config.optimizeDeps.include = [...new Set(config.optimizeDeps.include)]
   }
-} as NuxtHooks
+} as Partial<NuxtHooks>

--- a/nuxt-config/hooks/index.ts
+++ b/nuxt-config/hooks/index.ts
@@ -38,6 +38,14 @@ const HELIX_OPTIMIZE_DEPS = [
   '@shared/transformer/oracle'
 ]
 
+const VUE_DEDUPE_DEPS = [
+  'vue',
+  '@vue/shared',
+  '@vue/reactivity',
+  '@vue/runtime-core',
+  '@vue/runtime-dom'
+]
+
 function aliasBufferEntrypoint(config: any) {
   config.resolve = config.resolve || {}
 
@@ -51,6 +59,14 @@ function aliasBufferEntrypoint(config: any) {
     ...(config.resolve.alias || {}),
     buffer: 'buffer/'
   }
+}
+
+function dedupeVueRuntime(config: any) {
+  config.resolve = config.resolve || {}
+  config.resolve.dedupe = config.resolve.dedupe || []
+  config.resolve.dedupe = [
+    ...new Set([...config.resolve.dedupe, ...VUE_DEDUPE_DEPS])
+  ]
 }
 
 export default {
@@ -97,6 +113,7 @@ export default {
   },
   'vite:extendConfig'(config: any) {
     aliasBufferEntrypoint(config)
+    dedupeVueRuntime(config)
 
     if (isProduction) {
       return

--- a/nuxt-config/hooks/index.ts
+++ b/nuxt-config/hooks/index.ts
@@ -18,7 +18,24 @@ const HELIX_OPTIMIZE_DEPS = [
   'lightweight-charts',
   'html-to-image',
   'embla-carousel-vue',
-  '@injectivelabs/wallet-ledger'
+  '@injectivelabs/wallet-ledger',
+  '@shared/types',
+  '@shared/Service',
+  '@shared/utils',
+  '@shared/data/token',
+  '@shared/WalletService',
+  '@shared/utils/async',
+  '@shared/utils/helper',
+  '@shared/utils/lib',
+  '@shared/utils/network',
+  '@shared/utils/constant',
+  '@shared/utils/formatter',
+  '@shared/wallet/alchemy',
+  '@shared/Service/app/ethGasPrice',
+  '@shared/transformer/market',
+  '@shared/transformer/market/fundingRate',
+  '@shared/transformer/trade',
+  '@shared/transformer/oracle'
 ]
 
 export default {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,9 @@ import { metaTags } from './nuxt-config/meta'
 
 const isLocalLayer = process.env.LOCAL_LAYER === 'true'
 const isProduction = process.env.NODE_ENV === 'production'
+const injectiveUiLayerRef =
+  process.env.NUXT_INJECTIVE_UI_LAYER_REF ||
+  'bdab2818f0b26f7371f14960ead6a4d39ce9399c'
 
 export default defineNuxtConfig({
   hooks,
@@ -69,7 +72,7 @@ export default defineNuxtConfig({
   extends: [
     isLocalLayer
       ? '../injective-ui'
-      : 'github:InjectiveLabs/injective-ui#master'
+      : `github:InjectiveLabs/injective-ui#${injectiveUiLayerRef}`
   ],
   // @ts-ignore
   site: {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "license": "Apache-2.0",
   "author": "@InjectiveLabs",
   "private": true,
-  "browser": {
-    "buffer": true
-  },
   "scripts": {
     "fetch:data": "ts-node -P tsconfig-script.json ./scripts/marketMap.ts && ts-node -P tsconfig-script.json ./scripts/tokens.ts && ts-node -P tsconfig-script.json ./scripts/restriction.ts && ts-node -P tsconfig-script.json ./scripts/swap.ts && ts-node -P tsconfig-script.json ./scripts/denom.ts",
     "github:version": "ts-node -P tsconfig-script.json ./scripts/github.ts",
@@ -15,7 +12,7 @@
     "dev:local": "LOCAL_LAYER=true nuxi dev",
     "build": "nuxi build",
     "start": "nuxi start",
-    "postinstall": "pnpm update '@injectivelabs/*' --latest && pnpm fetch:data && pnpm github:version",
+    "postinstall": "pnpm fetch:data && pnpm github:version",
     "generate": "NODE_OPTIONS=--max-old-space-size=30720 nuxt generate",
     "generateNoSourceMap": "BUILD_SOURCEMAP=false NODE_OPTIONS=--max-old-space-size=30720 nuxt generate",
     "analyze": "NODE_OPTIONS=--max-old-space-size=30720 ANALYZE_BUNDLE=true nuxi build --analyze",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@vueuse/nuxt": "13.7.0",
     "apexcharts": "^4.0.0",
     "axios": "1.11.0",
+    "buffer": "6.0.3",
     "canvas-confetti": "^1.6.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gsap": "^3.12.5",
     "html-to-image": "^1.11.11",
     "js-confetti": "^0.12.0",
+    "js-sha3": "^0.9.3",
     "lightweight-charts": "^4.1.1",
     "lottie-web": "^5.12.2",
     "mixpanel-browser": "2.67.0",

--- a/plugins/00.buffer.client.ts
+++ b/plugins/00.buffer.client.ts
@@ -1,0 +1,11 @@
+import { Buffer } from 'buffer'
+
+const globalScope = globalThis as typeof globalThis & { Buffer?: typeof Buffer }
+
+export default defineNuxtPlugin(() => {
+  globalScope.Buffer = globalScope.Buffer || Buffer
+
+  const windowScope = window as Window & { Buffer?: typeof Buffer }
+
+  windowScope.Buffer = windowScope.Buffer || Buffer
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       js-confetti:
         specifier: ^0.12.0
         version: 0.12.0
+      js-sha3:
+        specifier: ^0.9.3
+        version: 0.9.3
       lightweight-charts:
         specifier: ^4.1.1
         version: 4.2.3
@@ -2097,36 +2100,42 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.80.0':
     resolution: {integrity: sha512-D2j5L9Z4OO42We0Lo2GkXT/AaNikzZJ8KZ9V2VVwu7kofI4RsO8kSu8ydWlqRlRdiAprmUpRZU/pNW0ZA7A68w==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.80.0':
     resolution: {integrity: sha512-2AztlLcio5OGil70wjRLbxbjlfS1yCTzO+CYan49vfUOCXpwSWwwLD2WDzFokhEXAzf8epbbu7pruYk8qorRRg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.80.0':
     resolution: {integrity: sha512-5GMKARe4gYHhA7utM8qOgv3WM7KAXGZGG3Jhvk4UQSRBp0v6PKFmHmz8Q93+Ep8w1m4NqRL30Zk9CZHMH/qi5g==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.80.0':
     resolution: {integrity: sha512-iw45N+OVnPioRQXLHfrsqEcTpydcGSHLphilS3aSpc4uVKnOqCybskKnbEnxsIJqHWbzDZeJgzuRuQa7EhNcqg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.80.0':
     resolution: {integrity: sha512-4+dhYznVM+L9Jh855JBbqVyDjwi3p8rpL7RfgN+Ee1oQMaZl2ZPy2shS1Kj56Xr5haTTVGdRKcIqTU8SuF37UQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-wasm32-wasi@0.80.0':
     resolution: {integrity: sha512-flADFeNwC1/XsBBsESAigsJZyONEBloQO86Z38ZNzLSuMmpGRdwB9gUwlPCQgDRND/aB+tvR29hKTSuQoS3yrg==}
@@ -2216,72 +2225,84 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.80.0':
     resolution: {integrity: sha512-y2NEhbFfKPdOkf3ZR/3xwJFJVji6IKxwXKHUN4bEdqpcO0tkXSCiP0MzTxjEY6ql2/MXdkqK0Ym92dYsRsgsyg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.70.0':
     resolution: {integrity: sha512-BJ+N25UWmHU624558ojSTnht3uFL00jV1c8qk1hnKf4cl6+ovFcoktRWAWSBlgLEP8tLlu8qgIhz875tMj2PkQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.80.0':
     resolution: {integrity: sha512-j3tKausSXwHS/Ej6ct2dmKJtw0UIME2XJmj6QfPT6LyUSNTndj4yXRXuMSrCOrX9/0qH9GhmqeL9ouU27dQRFw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.70.0':
     resolution: {integrity: sha512-nxu22nVuPA2xy1cxvBC0D5mVl0myqStOw3XBkVkDViNL01iPyuEFJd5VsM0GqsgrXvF95H/jrbMd+XWnto924g==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.80.0':
     resolution: {integrity: sha512-h+uPvyTcpTFd946fGPU57sZeec2qHPUYQRZeXHB2uuZjps+9pxQ5zIz0EBM/JgBtnwdtoR93RAu1YNAVbqY5Zw==}
     engines: {node: '>=20.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.70.0':
     resolution: {integrity: sha512-AQ6Xj97lYRxHZl94cZIHJxT5M1qkeEi+vQe+e7M2lAtjcURl8cwhZmWKSv4rt4BQRVfO3ys0bY8AgIh4eFJiqw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.80.0':
     resolution: {integrity: sha512-+u74hV+WwCPL4UBNOJaIGRozTCfZ7pM5JCEe8zAlMkKexftUzbtvW02314bVD9bqoRAL3Gg6jcZrjNjwDX2FwQ==}
     engines: {node: '>=20.0.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.70.0':
     resolution: {integrity: sha512-RIxaVsIxtG90CoX6/Okij8itaMrJp4SEJm1pSL0pz3hGo0yur3Il9M1mmGvOpW+avY8uHdwXIvf2qMnnTKZuoQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.80.0':
     resolution: {integrity: sha512-N9UGnWVWMlOJH+6550tqyBxd9qkMd0f4m+YRA0gly6efJTuLbPQpjkJm7pJbMu+GULcvSJ/Y0bkMAIQTtwP0vQ==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.70.0':
     resolution: {integrity: sha512-B3S0G4TlZ+WLdQq4mSQtt2ZW0MAkKWc8dla17tZY86kcXvvCWwACvj7I27Z/nSlb7uJOdRZS9/r6Gw0uAARNVQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-musl@0.80.0':
     resolution: {integrity: sha512-l2N/GlFEri27QBMi0e53V/SlpQotIvHbz+rZZG/EO+vn58ZEr0eTG+PjJoOY/T8+TQb8nrCtRe4S/zNDpV6zSQ==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.70.0':
     resolution: {integrity: sha512-QN8yxH7eHXTqed8Oo7ZUzOWn6hixXa8EVINLy21eLU9isoifSPKMswSmCXHxsM2L5rIIvzoaKfghGOru1mMQbw==}
@@ -2371,36 +2392,42 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.80.0':
     resolution: {integrity: sha512-kBBCQwr1GCkr/b0iXH+ijsg+CSPCAMSV2tu4LmG2PFaxBnZilMYfUyWHCAiskbbUADikecUfwX6hHIaQoMaixg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.80.0':
     resolution: {integrity: sha512-8CGJhHoD2Ttw8HtCNd/IWnGtL0Nsn448L2hZJtbDDGVUZUF4bbZFdXPnRt0QrEbupywoH6InN6q2imLous6xnw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.80.0':
     resolution: {integrity: sha512-V/Lb6m5loWzvdB/qo6eYvVXidQku/PA706JbeE/PPCup8At+BwOXnZjktv7LDxrpuqnO32tZDHUUc9Y3bzOEBw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.80.0':
     resolution: {integrity: sha512-03hHW04MQNb+ak27xo79nUkMjVu6146TNgeSapcDRATH4R0YMmXB2oPQK1K2nuBJzVZjBjH7Bus/I7tR3JasAg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.80.0':
     resolution: {integrity: sha512-BkXniuuHpo9cR2S3JDKIvmUrNvmm335owGW4rfp07HjVUsbq9e7bSnvOnyA3gXGdrPR2IgCWGi5nnXk2NN5Q0A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-wasm32-wasi@0.80.0':
     resolution: {integrity: sha512-jfRRXLtfSgTeJXBHj6qb+HHUd6hmYcyUNMBcTY8/k+JVsx0ThfrmCIufNlSJTt1zB+ugnMVMuQGeB0oF+aa86w==}
@@ -2448,36 +2475,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.1':
     resolution: {integrity: sha512-RJxlQQLkaMMIuWRozy+z2vEqbaQlCuaCgVZIUCzQLYggY22LZbP5Y1+ia+FD724Ids9e+XIyOLXLrLgQSHIthw==}
@@ -2685,56 +2718,67 @@ packages:
     resolution: {integrity: sha512-EwkC5N61ptruQ9wNkYfLgUWEGh+F3JZSGHkUWhaK2ISAK0d0xmiMKF0trFhRqPQFov5d9DmFiFIhWB5IC79OUA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.47.0':
     resolution: {integrity: sha512-Iz/g1X94vIjppA4H9hN3VEedw4ObC+u+aua2J/VPJnENEJ0GeCAPBN15nJc5pS5M8JPlUhOd3oqhOWX6Un4RHA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.47.0':
     resolution: {integrity: sha512-eYEYHYjFo/vb6k1l5uq5+Af9yuo9WaST/z+/8T5gkee+A0Sfx1NIPZtKMEQOLjm/oaeHFGpWaAO97gTPhouIfQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.47.0':
     resolution: {integrity: sha512-LX2x0/RszFEmDfjzL6kG/vihD5CkpJ+0K6lcbqX0jAopkkXeY2ZjStngdFMFW+BK7pyrqryJgy6Jt3+oyDxrSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.47.0':
     resolution: {integrity: sha512-0U+56rJmJvqBCwlPFz/BcxkvdiRdNPamBfuFHrOGQtGajSMJ2OqzlvOgwj5vReRQnSA6XMKw/JL1DaBhceil+g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.47.0':
     resolution: {integrity: sha512-2VKOsnNyvS05HFPKtmAWtef+nZyKCot/V3Jh/A5sYMhUvtthNjp6CjakYTtc5xZ8J8Fp5FKrUWGxptVtZ2OzEA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.47.0':
     resolution: {integrity: sha512-uY5UP7YZM4DMQiiP9Fl4/7O3UbT2p3uI0qvqLXZSGWBfyYuqi2DYQ48ExylgBN3T8AJork+b+mLGq6VXsxBfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.47.0':
     resolution: {integrity: sha512-qpcN2+/ivq3TcrXtZoHrS9WZplV3Nieh0gvnGb+SFZg7h/YkWsOXINJnjJRWHp9tEur7T8lMnMeQMPS7s9MjUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.47.0':
     resolution: {integrity: sha512-XfuI+o7a2/KA2tBeP+J1CT3siyIQyjpGEL6fFvtUdoHJK1k5iVI3qeGT2i5y6Bb+xQu08AHKBsUGJ2GsOZzXbQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.47.0':
     resolution: {integrity: sha512-ylkLO6G7oUiN28mork3caDmgXHqRuopAxjYDaOqs4CoU9pkfR0R/pGQb2V1x2Zg3tlFj4b/DvxZroxC3xALX6g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.47.0':
     resolution: {integrity: sha512-1L72a+ice8xKqJ2afsAVW9EfECOhNMAOC1jH65TgghLaHSFwNzyEdeye+1vRFDNy52OGKip/vajj0ONtX7VpAg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.47.0':
     resolution: {integrity: sha512-wluhdd1uNLk/S+ex2Yj62WFw3un2cZo2ZKXy9cOuoti5IhaPXSDSvxT3os+SJ1cjNorE1PwAOfiJU7QUH6n3Zw==}
@@ -3492,41 +3536,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       axios:
         specifier: 1.11.0
         version: 1.11.0
+      buffer:
+        specifier: 6.0.3
+        version: 6.0.3
       canvas-confetti:
         specifier: ^1.6.0
         version: 1.9.3

--- a/scripts/github.ts
+++ b/scripts/github.ts
@@ -8,18 +8,20 @@ const main = async () => {
     const git = simpleGit(process.cwd())
 
     const { latest } = await git.tags()
-    const { all } = await git.log({ from: latest, to: 'HEAD' })
+    const tag = process.env.GIT_TAG || latest || 'dev'
+    const { all } = latest
+      ? await git.log({ from: latest, to: 'HEAD' })
+      : await git.log(['-n', '20'])
     const branch = await git.revparse(['--abbrev-ref', 'HEAD'])
 
-    const gitTagLink = `https://github.com/InjectiveLabs/injective-helix/releases/tag/${
-      process.env.GIT_TAG || latest
-    }`
+    const repositoryUrl = 'https://github.com/InjectiveLabs/injective-helix-demo'
+    const gitTagLink = `${repositoryUrl}/releases/tag/${tag}`
 
     if (process.env.GIT_TAG) {
       storeJsonFile('app/json/gitVersion.json', {
         branch,
         gitTagLink,
-        tag: process.env.GIT_TAG,
+        tag,
         logs: []
       })
 
@@ -28,12 +30,12 @@ const main = async () => {
 
     const logs = all.map((log: any) => ({
       ...log,
-      commitLink: `https://github.com/InjectiveLabs/injective-helix/commit/${log.hash}`
+      commitLink: `${repositoryUrl}/commit/${log.hash}`
     }))
 
     storeJsonFile('app/json/gitVersion.json', {
       branch,
-      tag: latest,
+      tag,
       gitTagLink,
       logs
     })

--- a/scripts/github.ts
+++ b/scripts/github.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import 'dotenv/config'
 import { simpleGit } from 'simple-git'
 import { storeJsonFile } from './helper'
@@ -14,8 +13,10 @@ const main = async () => {
       : await git.log(['-n', '20'])
     const branch = await git.revparse(['--abbrev-ref', 'HEAD'])
 
-    const repositoryUrl = 'https://github.com/InjectiveLabs/injective-helix-demo'
-    const gitTagLink = `${repositoryUrl}/releases/tag/${tag}`
+    const repositoryUrl =
+      'https://github.com/InjectiveLabs/injective-helix-demo'
+    const gitTagLink =
+      tag === 'dev' ? '' : `${repositoryUrl}/releases/tag/${tag}`
 
     if (process.env.GIT_TAG) {
       storeJsonFile('app/json/gitVersion.json', {
@@ -28,7 +29,7 @@ const main = async () => {
       return
     }
 
-    const logs = all.map((log: any) => ({
+    const logs = all.map((log) => ({
       ...log,
       commitLink: `${repositoryUrl}/commit/${log.hash}`
     }))

--- a/scripts/helper.ts
+++ b/scripts/helper.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-console */
-import { dirname } from 'node:path'
-import { mkdirSync, existsSync, writeFileSync } from 'node:fs'
+import { dirname } from 'path'
+import { mkdirSync, existsSync, writeFileSync } from 'fs'
 
 export const storeJsonFile = (path: string, data: any) => {
   const dirPath = dirname(path)

--- a/scripts/restriction.ts
+++ b/scripts/restriction.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-console */
 import 'dotenv/config'
-import { writeFileSync } from 'node:fs'
+import { writeFileSync } from 'fs'
 import { HttpClient } from '@injectivelabs/utils'
 
 export const fetchOFACAndRestrictedAddresses = async (): Promise<any> => {

--- a/tsconfig-script.json
+++ b/tsconfig-script.json
@@ -4,6 +4,7 @@
     "module": "CommonJS",
     "strict": true,
     "outDir": "./dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary
- Pin the remote `injective-ui` layer to the Nuxt 3-compatible commit while allowing `NUXT_INJECTIVE_UI_LAYER_REF` overrides.
- Stop `postinstall` from mutating `@injectivelabs/*` packages, add the direct Buffer browser dependency, and pre-optimize the layer/demo deps needed for stable local dev startup.
- Make generated git version metadata work in shallow/no-tag clones and point links at `injective-helix-demo`.
- Update the public setup docs and `.env.example` for the working pnpm/mainnet local path.

## Root Cause
The demo was extending `injective-ui#master`, which has moved beyond this app's Nuxt 3 expectations, and `postinstall` was upgrading Injective packages past the locked dependency set. In dev mode, the app also needed deterministic Vite pre-optimization for shared layer imports plus a synchronous browser Buffer shim before the layer's async polyfill completes.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm clean-up && pnpm dev --host 127.0.0.1 --port 3077`
- Browser smoke test on `http://127.0.0.1:3077/spot/inj-usdt`: market page rendered with orderbook and no fresh Buffer/require/gRPC Buffer/Vue null hard errors after reload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Network env defaults switched to mainnet and Ethereum chain ID set to 1; mobile-connect env entry adjusted
  * New env option to pin a UI layer fallback reference

* **Documentation**
  * Install/run instructions updated to use HTTPS cloning and pnpm

* **Chores**
  * Build/tooling optimizations and dependency adjustments (including Buffer polyfill and dependency pins)
  * Git version/tag generation and related scripts improved

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-helix-demo/pull/1036)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->